### PR TITLE
Переводим Grid на абсолютные размеры

### DIFF
--- a/packages/ui/src/components/Grid/Grid.mdx
+++ b/packages/ui/src/components/Grid/Grid.mdx
@@ -35,32 +35,34 @@ import { Filler } from '../../helpers/Filler'
 <Props of={Col} />
 
 ## Пример использования
-<ThemeBackground>
-    <Container>
-        <Row>
-            <Col>
-                <Filler>1</Filler>
-            </Col>
-            <Col size={2}>
-                <Filler>2</Filler>
-            </Col>
-            <Col size={3}>
-                <Filler>3</Filler>
-            </Col>
-            <Col size={4}>
-                <Filler>4</Filler>
-            </Col>
-            <Col size={2}>
-                <Filler>2</Filler>
-            </Col>
-        </Row>
-        <Row>
-            <Col size={3} offset={1}>
-                <Filler>3 offset 1</Filler>
-            </Col>
-            <Col size={6} offset={2}>
-                <Filler>6 offset 2</Filler>
-            </Col>
-        </Row>
-    </Container>
-</ThemeBackground>
+<Playground>
+    <ThemeBackground>
+        <Container>
+            <Row>
+                <Col>
+                    <Filler>1</Filler>
+                </Col>
+                <Col size={2}>
+                    <Filler>2</Filler>
+                </Col>
+                <Col size={3}>
+                    <Filler>3</Filler>
+                </Col>
+                <Col size={4}>
+                    <Filler>4</Filler>
+                </Col>
+                <Col size={2}>
+                    <Filler>2</Filler>
+                </Col>
+            </Row>
+            <Row>
+                <Col size={3} offset={1}>
+                    <Filler>3 offset 1</Filler>
+                </Col>
+                <Col size={6} offset={2}>
+                    <Filler>6 offset 2</Filler>
+                </Col>
+            </Row>
+        </Container>
+    </ThemeBackground>
+</Playground>

--- a/packages/ui/src/components/Grid/Grid.stories.tsx
+++ b/packages/ui/src/components/Grid/Grid.stories.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
 import styled from 'styled-components';
+import { text, number } from '@storybook/addon-knobs';
+
+import { Filler } from '../../helpers/Filler';
 
 import { Container, Row, Col } from './Grid';
-import { Filler } from '../../helpers/Filler';
+
+const StyledDummyFiller = styled(Filler)`
+    opacity: 0.5;
+`;
 
 export default {
     title: 'Grid',
@@ -15,31 +21,40 @@ export default {
     ],
 };
 
-export const Default = () => (
+export const ColPlayground = () => (
     <Container>
         <Row>
-            <Col>
-                <Filler>1</Filler>
-            </Col>
-            <Col size={2}>
-                <Filler>2</Filler>
-            </Col>
-            <Col size={3}>
-                <Filler>3</Filler>
-            </Col>
             <Col size={4}>
-                <Filler>4</Filler>
-            </Col>
-            <Col size={2}>
-                <Filler>2</Filler>
+                <StyledDummyFiller>Dummy</StyledDummyFiller>
             </Col>
         </Row>
         <Row>
-            <Col size={3} offset={1}>
-                <Filler>3 offset 1</Filler>
+            <Col size={3}>
+                <StyledDummyFiller>Dummy</StyledDummyFiller>
             </Col>
-            <Col size={6} offset={2}>
-                <Filler>6 offset 2</Filler>
+            <Col size={1}>
+                <StyledDummyFiller>Dummy</StyledDummyFiller>
+            </Col>
+        </Row>
+        <Row>
+            <Col size={2}>
+                <StyledDummyFiller>Dummy</StyledDummyFiller>
+            </Col>
+            <Col size={2}>
+                <StyledDummyFiller>Dummy</StyledDummyFiller>
+            </Col>
+        </Row>
+        <Row>
+            <Col size={1}>
+                <StyledDummyFiller>Dummy</StyledDummyFiller>
+            </Col>
+            <Col size={3}>
+                <StyledDummyFiller>Dummy</StyledDummyFiller>
+            </Col>
+        </Row>
+        <Row>
+            <Col size={number('Size', 1)} offset={number('Offset', 0)}>
+                <Filler>{text('Content', 'Content')}</Filler>
             </Col>
         </Row>
     </Container>

--- a/packages/ui/src/components/ScrollList/ScrollList.stories.tsx
+++ b/packages/ui/src/components/ScrollList/ScrollList.stories.tsx
@@ -3,6 +3,9 @@ import { action } from '@storybook/addon-actions';
 import styled, { css } from 'styled-components';
 import { number } from '@storybook/addon-knobs';
 
+import { Filler } from '../../helpers/Filler';
+import { Col, Container, Row } from '../Grid/Grid';
+
 import { ListContext } from './ListContext';
 import { ScrollListCalcPosition, ScrollList } from './ScrollList';
 
@@ -10,6 +13,11 @@ interface ListItemProps {
     active: boolean;
     width: number;
     height: number;
+}
+
+interface ListGridItemProps {
+    size?: number;
+    active?: boolean;
 }
 
 const StyledListItemBody = styled.div`
@@ -50,6 +58,12 @@ const StyledVScrollList = styled(ScrollList)`
     position: relative;
 `;
 
+const StyledFiller = styled(Filler)<{ active?: boolean }>`
+    height: 200px;
+
+    ${({ active }) => active && 'background-color: rebeccapurple'};
+`;
+
 const ListItem: React.FC<ListItemProps> = ({ active, width, height, children }) => {
     const ref = React.useRef<HTMLDivElement | null>(null);
     const ctx = React.useContext(ListContext);
@@ -67,6 +81,23 @@ const ListItem: React.FC<ListItemProps> = ({ active, width, height, children }) 
     );
 };
 
+const ListGridItem: React.FC<ListGridItemProps> = ({ size, active, children }) => {
+    const ref = React.useRef<HTMLDivElement | null>(null);
+    const ctx = React.useContext(ListContext);
+
+    React.useEffect(() => {
+        ctx.register(ref);
+
+        return () => ctx.unregister(ref);
+    }, [ctx]);
+
+    return (
+        <Col ref={ref} size={size}>
+            <StyledFiller active={active}>{children}</StyledFiller>
+        </Col>
+    );
+};
+
 export default {
     title: 'ScrollList',
 };
@@ -77,6 +108,7 @@ export const HorizontalFixedWidth = () => {
     const index = number('Index', 0);
 
     let itemIndex = index;
+
     if (itemIndex < 0) {
         itemIndex = 0;
     } else if (itemIndex > items.length - 1) {
@@ -99,6 +131,7 @@ export const HorizontalArbitaryWidth = () => {
     const count = 11;
 
     let itemIndex = index;
+
     if (itemIndex < 0) {
         itemIndex = 0;
     } else if (itemIndex > count) {
@@ -153,6 +186,7 @@ export const VerticalFixedHeight = () => {
     const index = number('Index', 0);
 
     let itemIndex = index;
+
     if (itemIndex < 0) {
         itemIndex = 0;
     } else if (itemIndex > items.length - 1) {
@@ -175,6 +209,7 @@ export const VerticalArbitaryHeight = () => {
     const count = 11;
 
     let itemIndex = index;
+
     if (itemIndex < 0) {
         itemIndex = 0;
     } else if (itemIndex > count) {
@@ -228,6 +263,7 @@ export const VerticalWithCustomCalcPosition = () => {
     const index = number('Index', 0);
 
     let itemIndex = index;
+
     if (itemIndex < 0) {
         itemIndex = 0;
     } else if (itemIndex > items.length - 1) {
@@ -259,5 +295,40 @@ export const VerticalWithCustomCalcPosition = () => {
                 </ListItem>
             ))}
         </StyledVScrollList>
+    );
+};
+
+export const CarouselInLayout = () => {
+    const items = Array(number('Item count', 12)).fill(0);
+    const index = number('Index', 0);
+
+    let itemIndex = index;
+
+    if (itemIndex < 0) {
+        itemIndex = 0;
+    } else if (itemIndex > items.length - 1) {
+        itemIndex = items.length - 1;
+    }
+
+    return (
+        <Container>
+            <Row>
+                <Col size={2}>
+                    <Filler>Sidebar</Filler>
+                </Col>
+                <Col size={4}>
+                    <Filler>Carousel</Filler>
+                    <Row>
+                        <StyledHScrollList axis="x" index={itemIndex}>
+                            {items.map((_, i) => (
+                                <ListGridItem key={`item:${i}`} size={1} active={i === itemIndex}>
+                                    Card {i}
+                                </ListGridItem>
+                            ))}
+                        </StyledHScrollList>
+                    </Row>
+                </Col>
+            </Row>
+        </Container>
     );
 };


### PR DESCRIPTION
Размеры ячеек Col расчитываются исходя из размеров Container
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-styles@1.2.0-canary.3.3790010350104e46ddc642467541f7bf5ae495fe.0
  npm install @sberdevices/plasma-tokens@0.1.0-canary.3.3790010350104e46ddc642467541f7bf5ae495fe.0
  npm install @sberdevices/ui@0.7.0-canary.3.3790010350104e46ddc642467541f7bf5ae495fe.0
  # or 
  yarn add @sberdevices/plasma-styles@1.2.0-canary.3.3790010350104e46ddc642467541f7bf5ae495fe.0
  yarn add @sberdevices/plasma-tokens@0.1.0-canary.3.3790010350104e46ddc642467541f7bf5ae495fe.0
  yarn add @sberdevices/ui@0.7.0-canary.3.3790010350104e46ddc642467541f7bf5ae495fe.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
