### PR TITLE
feat(ui): использование Button beforeFocusOutline

### DIFF
--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -1,8 +1,9 @@
 import React, { forwardRef } from 'react';
 import styled, { css } from 'styled-components';
-import { typography, colors } from '@sberdevices/plasma-tokens';
+import { typography, accent } from '@sberdevices/plasma-tokens';
 
 import { views, View } from '../../mixins/views';
+import { beforeFocusOutline } from '../../mixins/beforeFocusOutline';
 import { PickOptional } from '../../types/PickOptional';
 
 const sizesToTypography = {
@@ -97,7 +98,7 @@ const getSizes = ({ pin, size, fullWidth = false, isTextOrChildren = false }: Si
     const circleRadius = height / 2;
     const outline = sizes[size].outline / fontSize;
     const elemRadius = convertMatrix(pinsMatrix[pin], `${squareRadius}em`, `${circleRadius}em`);
-    const beforeRadius = convertMatrix(pinsMatrix[pin], `${squareRadius + outline}em`, `${circleRadius + outline}em`);
+    const outlineRadius = convertMatrix(pinsMatrix[pin], `${squareRadius + outline}em`, `${circleRadius + outline}em`);
 
     return css`
         height: ${height}em;
@@ -123,16 +124,7 @@ const getSizes = ({ pin, size, fullWidth = false, isTextOrChildren = false }: Si
             width: 100%;
         `};
 
-        &::before {
-            top: -${outline}em;
-            left: -${outline}em;
-            border-radius: ${beforeRadius};
-            border-width: ${outline}em;
-        }
-
-        &:focus::before {
-            box-shadow: 0 0 0 ${outline}em ${colors.buttonFocused};
-        }
+        ${beforeFocusOutline(outline, outlineRadius, outline, accent)};
     `;
 };
 
@@ -188,19 +180,6 @@ const StyledButton = styled.button<StyledButtonProps>`
         &:hover, &:active {
             transform: none;
         }
-    }
-
-    &::before {
-        position: absolute;
-
-        width: 100%;
-        height: 100%;
-
-        border-color: transparent;
-        border-style: solid;
-        content: '';
-
-        transition: box-shadow 0.2s ease-in-out;
     }
 `;
 

--- a/packages/ui/src/mixins/beforeFocusOutline.ts
+++ b/packages/ui/src/mixins/beforeFocusOutline.ts
@@ -2,14 +2,20 @@ import { css } from 'styled-components';
 
 /**
  * @param {number} size (em)
- * @param {number} radius (em)
+ * @param {number|string} radius (em) Числовое значение в em или css-значение с ед./изм.
  * @param {number} offset (em)
  * @param {string} color (hex)
  * @param {boolean} focused Фокус через состояние или пропс
+ * @example
+ * // Выведет outline размером 2em, скруглением 5em, отступом 2em и цветом 'rebeccapurple'.
+ * beforeFocusOutline(2, 5, 2, 'rebeccapurple');
+ * @example
+ * // Выведет outline размером 4em, скруглением 10px 1px, без отступа и цветом 'greenyellow'.
+ * beforeFocusOutline(4, '10px 1px', 0, 'greenyellow');
  */
 export const beforeFocusOutline = (
     size: number,
-    radius: number,
+    radius: number|string,
     offset: number,
     color: string,
     focused?: boolean,
@@ -27,7 +33,7 @@ export const beforeFocusOutline = (
         height: 100%;
 
         border: ${size}em solid transparent;
-        border-radius: ${radius}em;
+        border-radius: ${typeof radius === 'number' ? `${radius}em` : radius};
         content: '';
 
         transition: box-shadow 0.2s ease-in-out;


### PR DESCRIPTION
closes #21 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/ui@0.10.0-canary.22.f6a33c9dec15d025e2463fe8c3ac317f52d862f2.0
  # or 
  yarn add @sberdevices/ui@0.10.0-canary.22.f6a33c9dec15d025e2463fe8c3ac317f52d862f2.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
