### PR TITLE
fix: add bootstrap in deploy script [skip ci]

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "release": "auto shipit",
     "chromatic": "lerna run chromatic",
     "build-storybook": "lerna run build-storybook",
-    "build-docz": "lerna run docz:build"
+    "build-docz": "lerna bootstrap --scope @sberdevices/ui && lerna run docz:build"
   },
   "devDependencies": {
     "@auto-it/conventional-commits": "9.60.1",


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/ui@0.10.1-canary.31.023a4fab083bc22e8bf40c3cbee1cffd4b2be4f2.0
  # or 
  yarn add @sberdevices/ui@0.10.1-canary.31.023a4fab083bc22e8bf40c3cbee1cffd4b2be4f2.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
