### PR TITLE
fix(ui): удалить CardPrice из поставки

### DIFF
--- a/packages/ui/src/components/Card/index.ts
+++ b/packages/ui/src/components/Card/index.ts
@@ -12,7 +12,8 @@ export type { CardContentProps } from './CardContent';
 export { CardMedia } from './CardMedia';
 export type { CardMediaProps } from './CardMedia';
 
-export { CardPrice } from './CardPrice';
-export type { CardPriceProps } from './CardPrice';
+// TODO: https://github.com/sberdevices/plasma/issues/81
+// export { CardPrice } from './CardPrice';
+// export type { CardPriceProps } from './CardPrice';
 
 export * from './CardTypography';


### PR DESCRIPTION
При импорте из корня любого компонента получаем ошибку:
```
./node_modules/@sberdevices/ui/components/Card/CardPrice.js
Module not found: Can't resolve '../../helpers/formatCurrency' in 'plasma-demo/node_modules/@sberdevices/ui/components/Card'
```

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/ui@0.20.1-canary.82.d5293ae70d9d9472accb8692185b10af187d72b1.0
  # or 
  yarn add @sberdevices/ui@0.20.1-canary.82.d5293ae70d9d9472accb8692185b10af187d72b1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
