### PR TITLE
ci: disable lerna check for user auth

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -15,6 +15,9 @@
                 "--unsafe-perm",
                 "--prefer-offline"
             ]
+        },
+        "publish": {
+            "verifyAccess": false
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "SberDevices Frontend Team <sberdevices.frontend@gmail.com>",
   "license": "Sber Public License at-nc-sa v.2",
   "scripts": {
-    "release": "auto shipit",
+    "release": "npm whoami && auto shipit",
     "chromatic": "lerna run chromatic",
     "build-storybook": "lerna run build-storybook",
     "build-docz": "lerna bootstrap --scope=@sberdevices/ui && lerna run docz:build",


### PR DESCRIPTION
Не знаю каким боком оно перестало работать или почему оно работало раньше,
но `lerna` перестала мочь достучаться до ручки /user:

```
lerna http fetch GET 403 https://registry.npmjs.org/-/npm/v1/user 199ms
403 Forbidden - GET https://registry.npmjs.org/-/npm/v1/user
lerna ERR! EWHOAMI Authentication error. Use `npm whoami` to troubleshoot.
```

в эту ручку lerna ходит вот тут: https://github.com/lerna/lerna/blob/72414ec1c679cf8a7ae4bfcefce52d50a6120a70/commands/publish/lib/get-profile-data.js#L11

туда нужно сходить чтобы получить имя пользователя npm O_o 
https://github.com/lerna/lerna/blob/72414ec1c679cf8a7ae4bfcefce52d50a6120a70/commands/publish/lib/get-npm-username.js#L10

и это нужно чтобы удостовериться что у пользователя есть права на паблишинг: https://github.com/lerna/lerna/blob/72414ec1c679cf8a7ae4bfcefce52d50a6120a70/commands/publish/index.js#L480-L489

соответсвенно в этом пр просто вырубаю эту проверку