### PR TITLE
fix(ui): Исправлен отступ от иконки 4рх в Badge

### DIFF
--- a/packages/ui/src/components/Badge/Badge.tsx
+++ b/packages/ui/src/components/Badge/Badge.tsx
@@ -10,11 +10,11 @@ import { applyView, ViewProps } from '../../mixins/applyView';
 export const badgeSizes = {
     l: {
         textMarginX: `${4 / scalingPixelBasis}rem`,
-        textMarginLeftAfterContent: `${6 / scalingPixelBasis}rem`,
+        textMarginLeftAfterContent: `${4 / scalingPixelBasis}rem`,
     },
     s: {
         textMarginX: `${2 / scalingPixelBasis}rem`,
-        textMarginLeftAfterContent: `${3 / scalingPixelBasis}rem`,
+        textMarginLeftAfterContent: `${2 / scalingPixelBasis}rem`,
     },
 };
 export const badgeRootSizes = {


### PR DESCRIPTION
Closes #85 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/ui@0.20.1-canary.113.6ce3afc4a1b2e76dc7854f6919b33e21c562fea8.0
  # or 
  yarn add @sberdevices/ui@0.20.1-canary.113.6ce3afc4a1b2e76dc7854f6919b33e21c562fea8.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
