### PR TITLE
fix(plasma-icons): Icon move className to root obj

### DIFF
--- a/packages/plasma-icons/src/IconRoot.tsx
+++ b/packages/plasma-icons/src/IconRoot.tsx
@@ -38,8 +38,8 @@ export const IconRoot: React.FC<IconRootProps> = ({ icon: IconComponent, size, c
     const w = `${sizeMap[size]}rem`;
 
     return (
-        <StyledRoot w={w}>
-            <IconComponent color={c} className={className} size={size} />
+        <StyledRoot w={w} className={className}>
+            <IconComponent color={c} size={size} />
         </StyledRoot>
     );
 };


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-icons@0.2.1-canary.145.a8f010f7e72f4eaf55e848ecd0decccb4d07a4f1.0
  npm install @sberdevices/ui@0.20.1-canary.145.a8f010f7e72f4eaf55e848ecd0decccb4d07a4f1.0
  # or 
  yarn add @sberdevices/plasma-icons@0.2.1-canary.145.a8f010f7e72f4eaf55e848ecd0decccb4d07a4f1.0
  yarn add @sberdevices/ui@0.20.1-canary.145.a8f010f7e72f4eaf55e848ecd0decccb4d07a4f1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
