### PR TITLE
fix(ui): Header missing exports

### DIFF
--- a/packages/ui/src/components/Header/Header.mdx
+++ b/packages/ui/src/components/Header/Header.mdx
@@ -12,14 +12,16 @@ import { ThemeBackground } from '../../helpers/ThemeBackground'
 import { Button } from '../Button';
 import { Container } from '../Grid'
 
-import { Header } from './Header'
-import { HeaderRoot } from './HeaderRoot'
-import { HeaderBack } from './HeaderBack'
-import { HeaderLogo } from './HeaderLogo'
-import { HeaderTitleWrapper } from './HeaderTitleWrapper'
-import { HeaderSubtitle } from './HeaderSubtitle'
-import { HeaderTitle } from './HeaderTitle'
-import { HeaderContent } from './HeaderContent'
+import {
+    Header,
+    HeaderRoot,
+    HeaderBack,
+    HeaderLogo,
+    HeaderTitleWrapper,
+    HeaderSubtitle,
+    HeaderTitle,
+    HeaderContent,
+} from '.';
 
 <TypoSelect />
 <ThemeSelect />

--- a/packages/ui/src/components/Header/Header.stories.tsx
+++ b/packages/ui/src/components/Header/Header.stories.tsx
@@ -10,14 +10,16 @@ import { Button } from '../Button';
 import { Container } from '../Grid';
 import { Tabs, TabItem } from '../Tabs';
 
-import { Header } from './Header';
-import { HeaderRoot } from './HeaderRoot';
-import { HeaderBack } from './HeaderBack';
-import { HeaderLogo } from './HeaderLogo';
-import { HeaderTitleWrapper } from './HeaderTitleWrapper';
-import { HeaderTitle } from './HeaderTitle';
-import { HeaderSubtitle } from './HeaderSubtitle';
-import { HeaderContent } from './HeaderContent';
+import {
+    Header,
+    HeaderRoot,
+    HeaderBack,
+    HeaderLogo,
+    HeaderTitleWrapper,
+    HeaderSubtitle,
+    HeaderTitle,
+    HeaderContent,
+} from '.';
 
 const MobileHeaderButtons = styled.div`
     display: none;

--- a/packages/ui/src/components/Header/index.ts
+++ b/packages/ui/src/components/Header/index.ts
@@ -1,7 +1,9 @@
 export { Header } from './Header';
+export { HeaderRoot } from './HeaderRoot';
 export { HeaderBack } from './HeaderBack';
 export { HeaderButton } from './HeaderButton';
 export { HeaderContent } from './HeaderContent';
 export { HeaderLogo } from './HeaderLogo';
-export { HeaderSubtitle } from './HeaderSubtitle';
+export { HeaderTitleWrapper } from './HeaderTitleWrapper';
 export { HeaderTitle } from './HeaderTitle';
+export { HeaderSubtitle } from './HeaderSubtitle';


### PR DESCRIPTION
closes: #168 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/ui@0.20.1-canary.169.2f5d0d0c930dd6167ad9ebea22773394da71e7b1.0
  # or 
  yarn add @sberdevices/ui@0.20.1-canary.169.2f5d0d0c930dd6167ad9ebea22773394da71e7b1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
