### PR TITLE
feat(plasma-icons): убрать фильтры

### DIFF
--- a/packages/plasma-icons/src/Icon.assets/Alarm.tsx
+++ b/packages/plasma-icons/src/Icon.assets/Alarm.tsx
@@ -4,7 +4,7 @@ import { IconProps } from '../IconRoot';
 
 export const Alarm: React.FC<IconProps> = (props) => (
     <svg width="100%" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
-        <g filter="url(#ic_24_alarm_svg__filter0_b)">
+        <g>
             <path
                 fillRule="evenodd"
                 clipRule="evenodd"
@@ -12,21 +12,5 @@ export const Alarm: React.FC<IconProps> = (props) => (
                 fill="currentColor"
             />
         </g>
-        <defs>
-            <filter
-                id="ic_24_alarm_svg__filter0_b"
-                x={-72.559}
-                y={-72.559}
-                width={168.402}
-                height={169.119}
-                filterUnits="userSpaceOnUse"
-                colorInterpolationFilters="sRGB"
-            >
-                <feFlood floodOpacity={0} result="BackgroundImageFix" />
-                <feGaussianBlur in="BackgroundImage" stdDeviation={37.28} />
-                <feComposite in2="SourceAlpha" operator="in" result="effect1_backgroundBlur" />
-                <feBlend in="SourceGraphic" in2="effect1_backgroundBlur" result="shape" />
-            </filter>
-        </defs>
     </svg>
 );

--- a/packages/plasma-icons/src/Icon.assets/Call.tsx
+++ b/packages/plasma-icons/src/Icon.assets/Call.tsx
@@ -4,7 +4,7 @@ import { IconProps } from '../IconRoot';
 
 export const Call: React.FC<IconProps> = (props) => (
     <svg width="100%" viewBox="0 0 26 26" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
-        <g filter="url(#ic_24_call_svg__filter0_d)">
+        <g>
             <path
                 fillRule="evenodd"
                 clipRule="evenodd"
@@ -12,24 +12,5 @@ export const Call: React.FC<IconProps> = (props) => (
                 fill="currentColor"
             />
         </g>
-        <defs>
-            <filter
-                id="ic_24_call_svg__filter0_d"
-                x={0.929}
-                y={0.929}
-                width={24.142}
-                height={24.142}
-                filterUnits="userSpaceOnUse"
-                colorInterpolationFilters="sRGB"
-            >
-                <feFlood floodOpacity={0} result="BackgroundImageFix" />
-                <feColorMatrix in="SourceAlpha" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" />
-                <feOffset />
-                <feGaussianBlur stdDeviation={2.5} />
-                <feColorMatrix values="0 0 0 0 0 0 0 0 0 0.484007 0 0 0 0 0.456084 0 0 0 0.1 0" />
-                <feBlend in2="BackgroundImageFix" result="effect1_dropShadow" />
-                <feBlend in="SourceGraphic" in2="effect1_dropShadow" result="shape" />
-            </filter>
-        </defs>
     </svg>
 );

--- a/packages/plasma-icons/src/Icon.assets/CallEnd.tsx
+++ b/packages/plasma-icons/src/Icon.assets/CallEnd.tsx
@@ -4,7 +4,7 @@ import { IconProps } from '../IconRoot';
 
 export const CallEnd: React.FC<IconProps> = (props) => (
     <svg width="100%" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
-        <g filter="url(#ic_24_call_end_svg__filter0_d)" clipPath="url(#ic_24_call_end_svg__clip0)">
+        <g clipPath="url(#ic_24_call_end_svg__clip0)">
             <path
                 fillRule="evenodd"
                 clipRule="evenodd"
@@ -16,23 +16,6 @@ export const CallEnd: React.FC<IconProps> = (props) => (
             <clipPath id="ic_24_call_end_svg__clip0">
                 <path fill="currentColor" d="M0 0h24v24H0z" />
             </clipPath>
-            <filter
-                id="ic_24_call_end_svg__filter0_d"
-                x={-1.745}
-                y={2.22}
-                width={27.491}
-                height={17.032}
-                filterUnits="userSpaceOnUse"
-                colorInterpolationFilters="sRGB"
-            >
-                <feFlood floodOpacity={0} result="BackgroundImageFix" />
-                <feColorMatrix in="SourceAlpha" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" />
-                <feOffset />
-                <feGaussianBlur stdDeviation={2.5} />
-                <feColorMatrix values="0 0 0 0 0 0 0 0 0 0.484007 0 0 0 0 0.456084 0 0 0 0.1 0" />
-                <feBlend in2="BackgroundImageFix" result="effect1_dropShadow" />
-                <feBlend in="SourceGraphic" in2="effect1_dropShadow" result="shape" />
-            </filter>
         </defs>
     </svg>
 );

--- a/packages/plasma-icons/src/Icon.assets/Play.tsx
+++ b/packages/plasma-icons/src/Icon.assets/Play.tsx
@@ -4,7 +4,7 @@ import { IconProps } from '../IconRoot';
 
 export const Play: React.FC<IconProps> = (props) => (
     <svg width="100%" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
-        <g filter="url(#ic_24_play_svg__filter0_b)">
+        <g>
             <path
                 fillRule="evenodd"
                 clipRule="evenodd"
@@ -12,21 +12,5 @@ export const Play: React.FC<IconProps> = (props) => (
                 fill="currentColor"
             />
         </g>
-        <defs>
-            <filter
-                id="ic_24_play_svg__filter0_b"
-                x={-101.731}
-                y={-104.486}
-                width={230.189}
-                height={232.972}
-                filterUnits="userSpaceOnUse"
-                colorInterpolationFilters="sRGB"
-            >
-                <feFlood floodOpacity={0} result="BackgroundImageFix" />
-                <feGaussianBlur in="BackgroundImage" stdDeviation={54.366} />
-                <feComposite in2="SourceAlpha" operator="in" result="effect1_backgroundBlur" />
-                <feBlend in="SourceGraphic" in2="effect1_backgroundBlur" result="shape" />
-            </filter>
-        </defs>
     </svg>
 );


### PR DESCRIPTION
С фильтрами иконку не видно под iOS, поболтала с человеком который рисовал, он предположил что это ненужные артефакты
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-icons@0.3.0-canary.207.03aed6bb45b9bbea66f273cd4fcac9fa2cd42d00.0
  npm install @sberdevices/ui@0.21.0-canary.207.03aed6bb45b9bbea66f273cd4fcac9fa2cd42d00.0
  # or 
  yarn add @sberdevices/plasma-icons@0.3.0-canary.207.03aed6bb45b9bbea66f273cd4fcac9fa2cd42d00.0
  yarn add @sberdevices/ui@0.21.0-canary.207.03aed6bb45b9bbea66f273cd4fcac9fa2cd42d00.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
