### PR TITLE
feat(ui): Добавлено правило переноса строк для типографики

### DIFF
--- a/packages/ui/src/components/Typography/Body/index.ts
+++ b/packages/ui/src/components/Typography/Body/index.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { body1, body2, body3 } from '@sberdevices/plasma-tokens';
 
-export const Body1 = styled.div(body1);
-export const Body2 = styled.div(body2);
-export const Body3 = styled.div(body3);
+export const Body1 = styled.div({ overflowWrap: 'break-word', hyphens: 'auto', ...body1 });
+export const Body2 = styled.div({ overflowWrap: 'break-word', hyphens: 'auto', ...body2 });
+export const Body3 = styled.div({ overflowWrap: 'break-word', hyphens: 'auto', ...body3 });

--- a/packages/ui/src/components/Typography/Button/index.ts
+++ b/packages/ui/src/components/Typography/Button/index.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
 import { button1, button2 } from '@sberdevices/plasma-tokens';
 
-export const Button1 = styled.div(button1);
-export const Button2 = styled.div(button2);
+export const Button1 = styled.div({ overflowWrap: 'break-word', hyphens: 'auto', ...button1 });
+export const Button2 = styled.div({ overflowWrap: 'break-word', hyphens: 'auto', ...button2 });

--- a/packages/ui/src/components/Typography/Caption/index.ts
+++ b/packages/ui/src/components/Typography/Caption/index.ts
@@ -1,4 +1,4 @@
 import styled from 'styled-components';
 import { caption } from '@sberdevices/plasma-tokens';
 
-export const Caption = styled.div(caption);
+export const Caption = styled.div({ overflowWrap: 'break-word', hyphens: 'auto', ...caption });

--- a/packages/ui/src/components/Typography/Display/index.ts
+++ b/packages/ui/src/components/Typography/Display/index.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { display1, display2, display3 } from '@sberdevices/plasma-tokens';
 
-export const Display1 = styled.div(display1);
-export const Display2 = styled.div(display2);
-export const Display3 = styled.div(display3);
+export const Display1 = styled.div({ overflowWrap: 'break-word', hyphens: 'auto', ...display1 });
+export const Display2 = styled.div({ overflowWrap: 'break-word', hyphens: 'auto', ...display2 });
+export const Display3 = styled.div({ overflowWrap: 'break-word', hyphens: 'auto', ...display3 });

--- a/packages/ui/src/components/Typography/Footnote/index.ts
+++ b/packages/ui/src/components/Typography/Footnote/index.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
 import { footnote1, footnote2 } from '@sberdevices/plasma-tokens';
 
-export const Footnote1 = styled.div(footnote1);
-export const Footnote2 = styled.div(footnote2);
+export const Footnote1 = styled.div({ overflowWrap: 'break-word', hyphens: 'auto', ...footnote1 });
+export const Footnote2 = styled.div({ overflowWrap: 'break-word', hyphens: 'auto', ...footnote2 });

--- a/packages/ui/src/components/Typography/Headline/index.ts
+++ b/packages/ui/src/components/Typography/Headline/index.ts
@@ -1,10 +1,10 @@
 import styled from 'styled-components';
 import { headline1, headline2, headline3, headline4 } from '@sberdevices/plasma-tokens';
 
-export const Headline1 = styled.div(headline1);
-export const Headline2 = styled.div(headline2);
-export const Headline3 = styled.div(headline3);
-export const Headline4 = styled.div(headline4);
+export const Headline1 = styled.div({ overflowWrap: 'break-word', hyphens: 'auto', ...headline1 });
+export const Headline2 = styled.div({ overflowWrap: 'break-word', hyphens: 'auto', ...headline2 });
+export const Headline3 = styled.div({ overflowWrap: 'break-word', hyphens: 'auto', ...headline3 });
+export const Headline4 = styled.div({ overflowWrap: 'break-word', hyphens: 'auto', ...headline4 });
 
 export const H1 = styled.h1({ margin: 0, ...headline1 });
 export const H2 = styled.h2({ margin: 0, ...headline2 });

--- a/packages/ui/src/components/Typography/Paragraph/index.ts
+++ b/packages/ui/src/components/Typography/Paragraph/index.ts
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
 import { paragraph1, paragraph2 } from '@sberdevices/plasma-tokens';
 
-export const ParagraphText1 = styled.div(paragraph1);
-export const ParagraphText2 = styled.div(paragraph2);
+export const ParagraphText1 = styled.div({ overflowWrap: 'break-word', hyphens: 'auto', ...paragraph1 });
+export const ParagraphText2 = styled.div({ overflowWrap: 'break-word', hyphens: 'auto', ...paragraph2 });
 
 export const P1 = styled.p({ margin: 0, ...paragraph1 });
 export const P = P1;

--- a/packages/ui/src/components/Typography/Underline/index.ts
+++ b/packages/ui/src/components/Typography/Underline/index.ts
@@ -1,4 +1,4 @@
 import styled, { CSSObject } from 'styled-components';
 import { underline } from '@sberdevices/plasma-tokens';
 
-export const Underline = styled.div(underline as CSSObject);
+export const Underline = styled.div({ overflowWrap: 'break-word', hyphens: 'auto', ...underline } as CSSObject);


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/ui@0.21.0-canary.225.32596c7775c9c0b32c0cbbbaf3b89ef30815c255.0
  # or 
  yarn add @sberdevices/ui@0.21.0-canary.225.32596c7775c9c0b32c0cbbbaf3b89ef30815c255.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
