### PR TITLE
fix: Возвращен экспорт CardPrice

### DIFF
--- a/packages/ui/src/components/Card/index.ts
+++ b/packages/ui/src/components/Card/index.ts
@@ -12,8 +12,7 @@ export type { CardContentProps } from './CardContent';
 export { CardMedia } from './CardMedia';
 export type { CardMediaProps } from './CardMedia';
 
-// TODO: https://github.com/sberdevices/plasma/issues/81
-// export { CardPrice } from './CardPrice';
-// export type { CardPriceProps } from './CardPrice';
+export { CardPrice } from './CardPrice';
+export type { CardPriceProps } from './CardPrice';
 
 export * from './CardTypography';


### PR DESCRIPTION
Задача https://github.com/sberdevices/plasma/issues/81 закрыта, но экспорт возвращен не был
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/ui@0.20.1-canary.236.93df47d7029a0356e13836d3e6af3363f63da67e.0
  # or 
  yarn add @sberdevices/ui@0.20.1-canary.236.93df47d7029a0356e13836d3e6af3363f63da67e.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
