### PR TITLE
fix(plasma-ui): circular dependency

### DIFF
--- a/packages/ui/src/components/Toast/ToastContext.tsx
+++ b/packages/ui/src/components/Toast/ToastContext.tsx
@@ -1,0 +1,16 @@
+import { createContext } from 'react';
+
+import { ToastInfo, Position } from './types';
+
+type ContextType = ToastInfo & {
+    showToast: (text: string, position?: Position, timeout?: number, fade?: boolean) => void;
+    hideToast: () => void;
+};
+
+export const ToastContext = createContext<ContextType>({
+    text: null,
+    position: null,
+    timeout: null,
+    showToast: () => undefined,
+    hideToast: () => undefined,
+});

--- a/packages/ui/src/components/Toast/ToastProvider.tsx
+++ b/packages/ui/src/components/Toast/ToastProvider.tsx
@@ -1,20 +1,8 @@
-import React, { createContext, useState, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 
 import { ToastInfo, Position } from './types';
 import { ToastController } from './ToastController';
-
-type ContextType = ToastInfo & {
-    showToast: (text: string, position?: Position, timeout?: number, fade?: boolean) => void;
-    hideToast: () => void;
-};
-
-export const ToastContext = createContext<ContextType>({
-    text: null,
-    position: null,
-    timeout: null,
-    showToast: () => undefined,
-    hideToast: () => undefined,
-});
+import { ToastContext } from './ToastContext';
 
 const DEFAULT_POSITION = 'bottom';
 const DEFAULT_TIMEOUT = 3000;

--- a/packages/ui/src/components/Toast/useToast.ts
+++ b/packages/ui/src/components/Toast/useToast.ts
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 
-import { ToastContext } from './ToastProvider';
+import { ToastContext } from './ToastContext';
 
 export const useToast = () => {
     const { showToast, hideToast } = useContext(ToastContext);


### PR DESCRIPTION
Сейчас проблема в том, что: 
1) **ToastProvide**r import ToastController
2) ToastController import useToast
3) useToast import **ToastProvide**r (точнее ToastContext из ToastProvider)
Это порождает Circular dependency. Данный PR фиксит эту проблему