### PR TITLE
fix(plasma-ui): circular dependency

### DIFF
--- a/packages/ui/src/components/Toast/ToastContext.tsx
+++ b/packages/ui/src/components/Toast/ToastContext.tsx
@@ -1,0 +1,16 @@
+import { createContext } from 'react';
+
+import { ToastInfo, Position } from './types';
+
+type ContextType = ToastInfo & {
+    showToast: (text: string, position?: Position, timeout?: number, fade?: boolean) => void;
+    hideToast: () => void;
+};
+
+export const ToastContext = createContext<ContextType>({
+    text: null,
+    position: null,
+    timeout: null,
+    showToast: () => undefined,
+    hideToast: () => undefined,
+});

--- a/packages/ui/src/components/Toast/ToastProvider.tsx
+++ b/packages/ui/src/components/Toast/ToastProvider.tsx
@@ -1,20 +1,8 @@
-import React, { createContext, useState, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 
 import { ToastInfo, Position } from './types';
 import { ToastController } from './ToastController';
-
-type ContextType = ToastInfo & {
-    showToast: (text: string, position?: Position, timeout?: number, fade?: boolean) => void;
-    hideToast: () => void;
-};
-
-export const ToastContext = createContext<ContextType>({
-    text: null,
-    position: null,
-    timeout: null,
-    showToast: () => undefined,
-    hideToast: () => undefined,
-});
+import { ToastContext } from './ToastContext';
 
 const DEFAULT_POSITION = 'bottom';
 const DEFAULT_TIMEOUT = 3000;

--- a/packages/ui/src/components/Toast/useToast.ts
+++ b/packages/ui/src/components/Toast/useToast.ts
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 
-import { ToastContext } from './ToastProvider';
+import { ToastContext } from './ToastContext';
 
 export const useToast = () => {
     const { showToast, hideToast } = useContext(ToastContext);


### PR DESCRIPTION
Сейчас проблема в том, что:

1. ToastProvider import ToastController
2. ToastController import useToast
3. useToast import ToastProvider (точнее ToastContext из ToastProvider)

Это порождает Circular dependency. Данный PR фиксит эту проблему
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/ui@0.20.1-canary.247.e3b4ba10ce7a9269867e1bae9127e6129513e862.0
  # or 
  yarn add @sberdevices/ui@0.20.1-canary.247.e3b4ba10ce7a9269867e1bae9127e6129513e862.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
