### PR TITLE
feat(plasma-ui): add shortMonth to DatePicker

### DIFF
--- a/packages/plasma-core/src/utils/formatters.ts
+++ b/packages/plasma-core/src/utils/formatters.ts
@@ -13,3 +13,8 @@ export const padZeroNumber = (value: number) => `${value}`.padStart(2, '0');
 export const monthLongName = (val: number): string =>
     last(new Intl.DateTimeFormat('ru-RU', { day: 'numeric', month: 'long' }).formatToParts(new Date().setMonth(val)))
         .value;
+
+export const monthShortName = (val: number): string =>
+    last(new Intl.DateTimeFormat('ru-RU', { day: 'numeric', month: 'short' }).formatToParts(new Date().setMonth(val)))
+        .value // Убираем `.` в конце: 'мар.' => 'мар', 'нояб.' => 'нояб'
+        .slice(0, -1);

--- a/packages/plasma-core/src/utils/index.ts
+++ b/packages/plasma-core/src/utils/index.ts
@@ -3,7 +3,7 @@ export { animatedScrollToX, animatedScrollToY } from './animatedScrollTo';
 export { convertRoundnessMatrix } from './roundness';
 export type { PinProps } from './roundness';
 
-export { padZeroNumber, monthLongName } from './formatters';
+export { padZeroNumber, monthLongName, monthShortName } from './formatters';
 export { formatCurrency } from './formatCurrency';
 
 export {

--- a/packages/ui/src/components/Pickers/DatePicker.tsx
+++ b/packages/ui/src/components/Pickers/DatePicker.tsx
@@ -10,6 +10,7 @@ const getValues = (date: Date) => [date.getFullYear(), date.getMonth(), date.get
 const defaultOptions = {
     years: true,
     months: true,
+    monthsShort: false,
     days: true,
 };
 
@@ -40,7 +41,7 @@ export interface DatePickerProps
     /**
      * Формат выводимого значения
      */
-    options?: typeof defaultOptions;
+    options?: Partial<typeof defaultOptions>;
 }
 
 /**
@@ -178,6 +179,18 @@ export const DatePicker: React.FC<DatePickerProps> = ({
             {options.months && (
                 <SimpleDatePicker
                     type="month"
+                    value={month}
+                    from={monthsInterval[0]}
+                    to={monthsInterval[1]}
+                    disabled={disabled}
+                    controls={controls}
+                    visibleItems={visibleItems}
+                    onChange={onMonthChange}
+                />
+            )}
+            {options.monthsShort && (
+                <SimpleDatePicker
+                    type="monthShort"
                     value={month}
                     from={monthsInterval[0]}
                     to={monthsInterval[1]}

--- a/packages/ui/src/components/Pickers/SimpleDatePicker.tsx
+++ b/packages/ui/src/components/Pickers/SimpleDatePicker.tsx
@@ -1,31 +1,20 @@
 import React from 'react';
-import styled, { css } from 'styled-components';
-import { scalingPixelBasis } from '@sberdevices/plasma-tokens';
-import { monthLongName } from '@sberdevices/plasma-core/utils';
+import styled from 'styled-components';
+import { monthLongName, monthShortName } from '@sberdevices/plasma-core/utils';
 import type { PickOptional } from '@sberdevices/plasma-core/types';
 
 import { Picker, PickerProps } from './Picker';
 
-type PickerType = 'day' | 'month' | 'year';
+type PickerType = 'day' | 'month' | 'monthShort' | 'year';
 
 const labelFormatter = {
     day: (value: number) => `${value}`,
     year: (value: number) => `${value}`,
+    monthShort: monthShortName,
     month: monthLongName,
 };
 
-const width = {
-    day: 48 / scalingPixelBasis,
-    year: 80 / scalingPixelBasis,
-    month: 180 / scalingPixelBasis,
-};
-
-const StyledPicker = styled(Picker)<{ $width: keyof typeof width }>`
-    ${({ $width }) =>
-        css`
-            width: ${width[$width]}rem;
-        `}
-
+const StyledPicker = styled(Picker)`
     & + & {
         margin-left: 1rem;
     }
@@ -60,7 +49,6 @@ export const SimpleDatePicker: React.FC<SimpleDatePickerProps> = ({
 
     return (
         <StyledPicker
-            $width={type}
             size="s"
             items={items}
             value={value}


### PR DESCRIPTION
@fanisco есть идеи как улучшить API ?
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/showcase@0.2.0-canary.267.c6cdad968161b07cb68bda2adea450a585f66618.0
  npm install @sberdevices/plasma-core@0.6.0-canary.267.c6cdad968161b07cb68bda2adea450a585f66618.0
  npm install @sberdevices/plasma-web@0.3.0-canary.267.c6cdad968161b07cb68bda2adea450a585f66618.0
  npm install @sberdevices/ui@0.21.0-canary.267.c6cdad968161b07cb68bda2adea450a585f66618.0
  # or 
  yarn add @sberdevices/showcase@0.2.0-canary.267.c6cdad968161b07cb68bda2adea450a585f66618.0
  yarn add @sberdevices/plasma-core@0.6.0-canary.267.c6cdad968161b07cb68bda2adea450a585f66618.0
  yarn add @sberdevices/plasma-web@0.3.0-canary.267.c6cdad968161b07cb68bda2adea450a585f66618.0
  yarn add @sberdevices/ui@0.21.0-canary.267.c6cdad968161b07cb68bda2adea450a585f66618.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
