### PR TITLE
fix(ui): Использование div вместо img в компоненте Image

### DIFF
--- a/packages/ui/src/components/Image/Image.tsx
+++ b/packages/ui/src/components/Image/Image.tsx
@@ -43,6 +43,7 @@ export type ImageBaseProps = (HeightProps | RatioProps | CustomRatioProps) &
     React.ImgHTMLAttributes<HTMLImageElement> & {
         src: string;
         alt?: string;
+        base?: 'div' | 'img';
     };
 
 export type ImageProps = ImageBaseProps & {
@@ -76,16 +77,26 @@ const StyledImg = styled.img`
     width: 100%;
 `;
 
+const StyledDivImg = styled.div<{ src: string }>`
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    background-image: ${({ src }) => `url(${src})`};
+    background-position: center;
+    background-size: cover;
+`;
+
 /**
  * Компонент для отображения картинок.
  */
-export const Image: React.FC<ImageProps> = ({ src, alt, ...props }) => (
+export const Image: React.FC<ImageProps> = ({ src, base = 'img', alt, ...props }) => (
     <StyledRoot
         $ratio={'ratio' in props ? props.ratio : undefined}
         $customRatio={'customRatio' in props ? props.customRatio : undefined}
         $height={'height' in props ? props.height : undefined}
         {...props}
     >
-        <StyledImg src={src} alt={alt} />
+        {base === 'img' && <StyledImg src={src} alt={alt} />}
+        {base === 'div' && <StyledDivImg src={src} />}
     </StyledRoot>
 );


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/showcase@0.2.0-canary.271.139faf71fd120fbaafe4dd6fe3499cd42d449cc2.0
  npm install @sberdevices/ui@0.21.0-canary.271.139faf71fd120fbaafe4dd6fe3499cd42d449cc2.0
  # or 
  yarn add @sberdevices/showcase@0.2.0-canary.271.139faf71fd120fbaafe4dd6fe3499cd42d449cc2.0
  yarn add @sberdevices/ui@0.21.0-canary.271.139faf71fd120fbaafe4dd6fe3499cd42d449cc2.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
