### PR TITLE
feat(ui): Add base to props in Image component

### DIFF
--- a/docs/showcase/src/ui/Image.stories.tsx
+++ b/docs/showcase/src/ui/Image.stories.tsx
@@ -22,6 +22,11 @@ const sections = {
         '9 / 16': <Image key="9 / 16" src="./images/180_320_9.jpg" ratio="9 / 16" />,
         '1 / 2': <Image key="1 / 2" src="./images/160_320_9.jpg" ratio="1 / 2" />,
     },
+    Div: {
+        '1 / 1': <Image base="div" key="Div square" src={src} ratio="1 / 1" style={{ width: 320 }} />,
+        '4 / 3': <Image base="div" key="Div 4 / 4" src="./images/240_320_9.jpg" ratio="4 / 3" style={{ width: 320 }} />,
+        '3 / 4': <Image base="div" key="Div 3 / 4" src="./images/240_320_9.jpg" ratio="3 / 4" style={{ width: 320 }} />,
+    },
 };
 
 export const Default = () => <CardShowcase sections={sections} colWidth="10rem" />;

--- a/packages/plasma-ui/src/components/Image/Image.stories.tsx
+++ b/packages/plasma-ui/src/components/Image/Image.stories.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { select } from '@storybook/addon-knobs';
 
 import { InSpacing } from '../../helpers/StoryDecorators';
 
@@ -10,8 +11,21 @@ export default {
     decorators: [InSpacing],
 };
 
+const bases = ['div', 'img'];
+
 export const Default = () => (
     <div style={{ maxWidth: '10rem' }}>
         <Image src="./images/320_320_9.jpg" ratio="1 / 1" />
+    </div>
+);
+
+export const Basic = () => (
+    <div style={{ maxWidth: '10rem' }}>
+        <Image
+            src="./images/320_320_9.jpg"
+            ratio="1 / 1"
+            base={select('base', bases, 'div') as 'div'}
+            style={{ position: 'relative' }}
+        />
     </div>
 );

--- a/packages/plasma-ui/src/components/Image/Image.tsx
+++ b/packages/plasma-ui/src/components/Image/Image.tsx
@@ -43,6 +43,7 @@ export type ImageBaseProps = (HeightProps | RatioProps | CustomRatioProps) &
     React.ImgHTMLAttributes<HTMLImageElement> & {
         src: string;
         alt?: string;
+        base?: 'div' | 'img';
     };
 
 export type ImageProps = ImageBaseProps & {
@@ -50,6 +51,7 @@ export type ImageProps = ImageBaseProps & {
 };
 
 const StyledRoot = styled.div<StyledRootProps>`
+    position: relative;
     display: block;
     box-sizing: border-box;
     overflow: hidden;
@@ -76,16 +78,26 @@ const StyledImg = styled.img`
     width: 100%;
 `;
 
+const StyledDivImg = styled.div<{ src: string }>`
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    background-image: ${({ src }) => `url(${src})`};
+    background-position: center;
+    background-size: cover;
+`;
+
 /**
  * Компонент для отображения картинок.
  */
-export const Image: React.FC<ImageProps> = ({ src, alt, ...props }) => (
+export const Image: React.FC<ImageProps> = ({ src, base = 'img', alt, ...props }) => (
     <StyledRoot
         $ratio={'ratio' in props ? props.ratio : undefined}
         $customRatio={'customRatio' in props ? props.customRatio : undefined}
         $height={'height' in props ? props.height : undefined}
         {...props}
     >
-        <StyledImg src={src} alt={alt} />
+        {base === 'img' && <StyledImg src={src} alt={alt} />}
+        {base === 'div' && <StyledDivImg src={src} />}
     </StyledRoot>
 );


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/showcase@0.6.0-canary.298.a873cb00e80d3d10910fe42b8b2517d12d9c232c.0
  npm install @sberdevices/plasma-ui@1.3.0-canary.298.a873cb00e80d3d10910fe42b8b2517d12d9c232c.0
  # or 
  yarn add @sberdevices/showcase@0.6.0-canary.298.a873cb00e80d3d10910fe42b8b2517d12d9c232c.0
  yarn add @sberdevices/plasma-ui@1.3.0-canary.298.a873cb00e80d3d10910fe42b8b2517d12d9c232c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
