### PR TITLE
fix(plasma-ui): fix setting props in TextField component

### DIFF
--- a/docs/showcase/src/helpers/TextFieldShowcase.tsx
+++ b/docs/showcase/src/helpers/TextFieldShowcase.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import type { TextFieldProps } from '@sberdevices/plasma-ui/components/TextField';
 
 import { actionWithPersistedEvent } from './actionWithPersistedEvent';
 import { ShowcaseHead } from './Showcase';
@@ -19,20 +18,17 @@ const onFocus = actionWithPersistedEvent('onFocus');
 const onBlur = actionWithPersistedEvent('onBlur');
 const handlers = { onChange, onFocus, onBlur };
 
+interface ShowcaseProps<T> {
+    props: T;
+    rows: Record<string, T>;
+    cols: Record<string, T>;
+    component: React.ComponentType<T>;
+}
+
 /**
  * Шоукейсы - обертки для демонстрации / тестирования полной раскладки презентуемого компонента.
  */
-export const Showcase = ({
-    props,
-    rows,
-    cols,
-    component: TextField,
-}: {
-    props: TextFieldProps;
-    rows: Record<string, TextFieldProps>;
-    cols: Record<string, TextFieldProps>;
-    component: any;
-}) => {
+export function Showcase<T>({ props, rows, cols, component: TextField }: ShowcaseProps<T>) {
     const colsList = Object.entries(cols);
 
     return (
@@ -53,4 +49,4 @@ export const Showcase = ({
             ))}
         </StyledGrid>
     );
-};
+}

--- a/packages/plasma-core/src/types/InputHTMLAttributes.ts
+++ b/packages/plasma-core/src/types/InputHTMLAttributes.ts
@@ -28,6 +28,18 @@ export interface InputHTMLAttributes<T> extends DisabledProps {
      */
     placeholder?: string;
     /**
+     * Флаг обязательности поля
+     */
+    required?: boolean;
+    /**
+     * Минимальная длина значения поля
+     */
+    minLength?: number;
+    /**
+     * Максимальная длина значения поля
+     */
+    maxLength?: number;
+    /**
      * Обработчик изменения элемента формы
      */
     onChange?: React.InputHTMLAttributes<T>['onChange'];

--- a/packages/plasma-ui/src/components/TextField/TextField.tsx
+++ b/packages/plasma-ui/src/components/TextField/TextField.tsx
@@ -135,7 +135,23 @@ const StyledRoot = styled(TextFieldRoot)<StyledRootProps>`
  */
 export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
     (
-        { value, label, helperText, disabled, contentLeft, contentRight, status, onChange, onFocus, onBlur, ...rest },
+        {
+            value,
+            label,
+            helperText,
+            disabled,
+            contentLeft,
+            contentRight,
+            status,
+            onChange,
+            onFocus,
+            onBlur,
+            className,
+            id,
+            style,
+            type = 'text',
+            ...rest
+        },
         ref,
     ) => (
         <StyledRoot
@@ -143,17 +159,21 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
             disabled={disabled}
             isContentLeft={!!contentLeft}
             isContentRight={!!contentRight}
-            {...rest}
+            className={className}
+            style={style}
+            id={id}
         >
             <StyledInputWrapper>
                 {contentLeft && <StyledContent>{contentLeft}</StyledContent>}
                 <StyledInput
                     ref={ref}
                     value={value}
+                    type={type}
                     disabled={disabled}
                     onChange={onChange}
                     onFocus={onFocus}
                     onBlur={onBlur}
+                    {...rest}
                 />
                 {label && <StyledLabel isValue={!!value}>{label}</StyledLabel>}
                 {contentRight && <StyledContent>{contentRight}</StyledContent>}

--- a/packages/plasma-web/src/components/TextArea/TextArea.tsx
+++ b/packages/plasma-web/src/components/TextArea/TextArea.tsx
@@ -33,11 +33,33 @@ const StyledTextArea = styled.textarea<TextAreaProps>`
  */
 export const TextArea = React.forwardRef<HTMLInputElement, TextAreaProps>(
     (
-        { value, placeholder, helperText, disabled, contentRight, status, resize, onChange, onFocus, onBlur, ...rest },
+        {
+            value,
+            placeholder,
+            helperText,
+            disabled,
+            contentRight,
+            status,
+            resize,
+            onChange,
+            onFocus,
+            onBlur,
+            style,
+            id,
+            className,
+            ...rest
+        },
         ref,
     ) => {
         return (
-            <TextFieldRoot disabled={disabled} status={status} isContentRight={!!contentRight} {...rest}>
+            <TextFieldRoot
+                disabled={disabled}
+                status={status}
+                isContentRight={!!contentRight}
+                className={className}
+                id={id}
+                style={style}
+            >
                 <StyledInputWrapper resize={resize}>
                     <TextFieldInput
                         as={StyledTextArea}
@@ -51,6 +73,7 @@ export const TextArea = React.forwardRef<HTMLInputElement, TextAreaProps>(
                         onChange={onChange}
                         onFocus={onFocus}
                         onBlur={onBlur}
+                        {...rest}
                     />
                     {contentRight && <TextFieldContent>{contentRight}</TextFieldContent>}
                 </StyledInputWrapper>

--- a/packages/plasma-web/src/components/TextField/TextField.tsx
+++ b/packages/plasma-web/src/components/TextField/TextField.tsx
@@ -91,9 +91,33 @@ export const TextFieldContent = styled.div`
  * Поле ввода текста.
  */
 export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
-    ({ value, placeholder, helperText, disabled, contentRight, status, onChange, onFocus, onBlur, ...rest }, ref) => {
+    (
+        {
+            value,
+            placeholder,
+            helperText,
+            disabled,
+            contentRight,
+            status,
+            onChange,
+            onFocus,
+            onBlur,
+            style,
+            id,
+            className,
+            ...rest
+        },
+        ref,
+    ) => {
         return (
-            <TextFieldRoot disabled={disabled} status={status} isContentRight={!!contentRight} {...rest}>
+            <TextFieldRoot
+                disabled={disabled}
+                status={status}
+                isContentRight={!!contentRight}
+                className={className}
+                id={id}
+                style={style}
+            >
                 <TextFieldInputWrapper>
                     <TextFieldInput
                         ref={ref}
@@ -105,6 +129,7 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
                         onChange={onChange}
                         onFocus={onFocus}
                         onBlur={onBlur}
+                        {...rest}
                     />
                     {contentRight && <TextFieldContent>{contentRight}</TextFieldContent>}
                 </TextFieldInputWrapper>


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/showcase@0.7.2-canary.299.54678e3ddbd5698a9f3bc413de2e5c3743026136.0
  npm install @sberdevices/plasma-core@1.1.1-canary.299.54678e3ddbd5698a9f3bc413de2e5c3743026136.0
  npm install @sberdevices/plasma-icons@1.1.2-canary.299.54678e3ddbd5698a9f3bc413de2e5c3743026136.0
  npm install @sberdevices/plasma-ui@1.3.2-canary.299.54678e3ddbd5698a9f3bc413de2e5c3743026136.0
  npm install @sberdevices/plasma-web@1.2.2-canary.299.54678e3ddbd5698a9f3bc413de2e5c3743026136.0
  # or 
  yarn add @sberdevices/showcase@0.7.2-canary.299.54678e3ddbd5698a9f3bc413de2e5c3743026136.0
  yarn add @sberdevices/plasma-core@1.1.1-canary.299.54678e3ddbd5698a9f3bc413de2e5c3743026136.0
  yarn add @sberdevices/plasma-icons@1.1.2-canary.299.54678e3ddbd5698a9f3bc413de2e5c3743026136.0
  yarn add @sberdevices/plasma-ui@1.3.2-canary.299.54678e3ddbd5698a9f3bc413de2e5c3743026136.0
  yarn add @sberdevices/plasma-web@1.2.2-canary.299.54678e3ddbd5698a9f3bc413de2e5c3743026136.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
