### PR TITLE
fix: bump peerDeps

### DIFF
--- a/packages/plasma-icons/package.json
+++ b/packages/plasma-icons/package.json
@@ -12,7 +12,7 @@
     "author": "SberDevices Frontend Team <sberdevices.frontend@gmail.com>",
     "license": "Sber Public License at-nc-sa v.2",
     "peerDependencies": {
-        "@sberdevices/plasma-tokens": "^0.4.0",
+        "@sberdevices/plasma-tokens": "^1.0.0",
         "@types/node": "^12.12.30",
         "@types/react": "^16.9.38",
         "@types/react-dom": "^16.9.8",

--- a/packages/plasma-ui/package.json
+++ b/packages/plasma-ui/package.json
@@ -16,8 +16,8 @@
         "lodash.throttle": "4.1.1"
     },
     "peerDependencies": {
-        "@sberdevices/plasma-icons": "^0.2.0",
-        "@sberdevices/plasma-tokens": "^0.2.0",
+        "@sberdevices/plasma-icons": "^1.0.0",
+        "@sberdevices/plasma-tokens": "^1.0.0",
         "@types/node": "^12.12.30",
         "@types/react": "^16.9.38",
         "@types/react-dom": "^16.9.8",
@@ -80,17 +80,7 @@
         "title": "SberDevices Design System",
         "url": "https://5f96ec813d800900227e3b93-eobodfvrnh.chromatic.com/"
     },
-    "files": [
-        "components",
-        "hocs",
-        "hooks",
-        "mixins",
-        "types",
-        "utils",
-        "index.d.ts",
-        "index.js",
-        "es"
-    ],
+    "files": ["components", "hocs", "hooks", "mixins", "types", "utils", "index.d.ts", "index.js", "es"],
     "contributors": [
         "Vasiliy Loginevskiy",
         "Антонов Игорь Александрович",

--- a/packages/plasma-web/package.json
+++ b/packages/plasma-web/package.json
@@ -4,21 +4,10 @@
     "description": "SberDevices Design System / React UI kit for web applications",
     "author": "SberDevices Frontend Team <sberdevices.frontend@gmail.com>",
     "license": "Sber Public License at-nc-sa v.2",
-    "keywords": [
-        "design-system",
-        "react-components",
-        "ui-kit",
-        "react"
-    ],
+    "keywords": ["design-system", "react-components", "ui-kit", "react"],
     "main": "index.js",
     "types": "index.d.ts",
-    "files": [
-        "components",
-        "tokens",
-        "index.d.ts",
-        "index.js",
-        "es"
-    ],
+    "files": ["components", "tokens", "index.d.ts", "index.js", "es"],
     "repository": {
         "type": "git",
         "url": "ssh://git@github.com:sberdevices/plasma.git",
@@ -29,7 +18,7 @@
         "@sberdevices/plasma-tokens-web": "1.1.0"
     },
     "peerDependencies": {
-        "@sberdevices/plasma-icons": "^0.2.0",
+        "@sberdevices/plasma-icons": "^1.0.0",
         "react": "^16.13.1",
         "react-dom": "^16.13.1",
         "styled-components": "^5.1.1"
@@ -74,10 +63,6 @@
         "storybook": "start-storybook -s .storybook/public -p ${PORT:-7007} -c .storybook",
         "storybook:build": "build-storybook -s .storybook/public -c .storybook -o build-sb"
     },
-    "contributors": [
-        "Vasiliy Loginevskiy",
-        "Anton Vinogradov",
-        "Fanil Zubairov"
-    ],
+    "contributors": ["Vasiliy Loginevskiy", "Anton Vinogradov", "Fanil Zubairov"],
     "sideEffects": false
 }


### PR DESCRIPTION
fixes: #306 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/showcase@0.7.1-canary.307.cd9cef0fdee7c1dbc07c45cd8a1c24c09c85a277.0
  npm install @sberdevices/plasma-icons@1.1.1-canary.307.cd9cef0fdee7c1dbc07c45cd8a1c24c09c85a277.0
  npm install @sberdevices/plasma-ui@1.3.1-canary.307.cd9cef0fdee7c1dbc07c45cd8a1c24c09c85a277.0
  npm install @sberdevices/plasma-web@1.2.1-canary.307.cd9cef0fdee7c1dbc07c45cd8a1c24c09c85a277.0
  # or 
  yarn add @sberdevices/showcase@0.7.1-canary.307.cd9cef0fdee7c1dbc07c45cd8a1c24c09c85a277.0
  yarn add @sberdevices/plasma-icons@1.1.1-canary.307.cd9cef0fdee7c1dbc07c45cd8a1c24c09c85a277.0
  yarn add @sberdevices/plasma-ui@1.3.1-canary.307.cd9cef0fdee7c1dbc07c45cd8a1c24c09c85a277.0
  yarn add @sberdevices/plasma-web@1.2.1-canary.307.cd9cef0fdee7c1dbc07c45cd8a1c24c09c85a277.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
