### PR TITLE
feat(plasma-ui): Add new scrollAlign values for Carousel

### DIFF
--- a/packages/plasma-ui/src/components/Carousel/Carousel.stories.tsx
+++ b/packages/plasma-ui/src/components/Carousel/Carousel.stories.tsx
@@ -40,7 +40,7 @@ export const Basic = () => {
     });
 
     const animatedScrollByIndex = boolean('animatedScrollByIndex', isSberbox);
-    const scrollAlign = select('scrollAlign', ['center', 'start'], 'start');
+    const scrollAlign = select('scrollAlign', ['center', 'start', 'end', 'activeDirection'], 'start');
     const scrollSnapType = !isSberbox ? select('scrollSnapType', snapTypes, 'mandatory') : undefined;
     const scrollSnapAlign = !isSberbox ? select('scrollSnapAlign', snapAlign, 'start') : undefined;
     const detectActive = boolean('detectActive', true) as true;
@@ -87,7 +87,7 @@ export const Vertical = () => {
     });
 
     const animatedScrollByIndex = boolean('animatedScrollByIndex', false);
-    const scrollAlign = select('scrollAlign', ['center', 'start'], 'center');
+    const scrollAlign = select('scrollAlign', ['center', 'start', 'end', 'activeDirection'], 'center');
     const scrollSnapType = select('scrollSnapType', snapTypes, 'mandatory');
     const scrollSnapAlign = select('scrollSnapAlign', snapAlign, 'center');
     const detectActive = boolean('detectActive', true) as true;


### PR DESCRIPTION
I added two new values for the scrollAlign field. "end" which works symmetrically to the "start" value. And "activeDirection", when used, the active element pulls the window behind it, in the direction towards which there is a scroll 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/showcase@0.12.0-canary.317.a27d388d2a8bc3378224367aa478b99f689dead6.0
  npm install @sberdevices/plasma-ui@1.8.0-canary.317.a27d388d2a8bc3378224367aa478b99f689dead6.0
  # or 
  yarn add @sberdevices/showcase@0.12.0-canary.317.a27d388d2a8bc3378224367aa478b99f689dead6.0
  yarn add @sberdevices/plasma-ui@1.8.0-canary.317.a27d388d2a8bc3378224367aa478b99f689dead6.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
