### PR TITLE
fix(plasma-core): Badge: fix padding for size s

### DIFF
--- a/docs/showcase/package.json
+++ b/docs/showcase/package.json
@@ -1,7 +1,9 @@
 {
     "name": "@sberdevices/showcase",
     "private": true,
+    "version": "0.9.1",
     "description": "SberDevices Design System Showcase",
+    "files": [],
     "repository": {
         "type": "git",
         "url": "ssh://git@github.com:sberdevices/plasma.git",

--- a/packages/plasma-core/src/components/Badge/Badge.tsx
+++ b/packages/plasma-core/src/components/Badge/Badge.tsx
@@ -35,7 +35,6 @@ export const badgeRootSizes = {
         height: '1rem',
         padding: '0.125rem',
         'min-width': '1rem',
-        'padding-left': '0.25rem',
         'border-radius': '0.5rem',
         'font-size': '0.625rem',
     },


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/showcase@0.9.2-canary.318.5062609e6aa23a5c920306bb15d498a41935c1a2.0
  npm install @sberdevices/plasma-core@1.3.2-canary.318.5062609e6aa23a5c920306bb15d498a41935c1a2.0
  npm install @sberdevices/plasma-icons@1.3.2-canary.318.5062609e6aa23a5c920306bb15d498a41935c1a2.0
  npm install @sberdevices/plasma-ui@1.5.3-canary.318.5062609e6aa23a5c920306bb15d498a41935c1a2.0
  npm install @sberdevices/plasma-web@1.4.2-canary.318.5062609e6aa23a5c920306bb15d498a41935c1a2.0
  # or 
  yarn add @sberdevices/showcase@0.9.2-canary.318.5062609e6aa23a5c920306bb15d498a41935c1a2.0
  yarn add @sberdevices/plasma-core@1.3.2-canary.318.5062609e6aa23a5c920306bb15d498a41935c1a2.0
  yarn add @sberdevices/plasma-icons@1.3.2-canary.318.5062609e6aa23a5c920306bb15d498a41935c1a2.0
  yarn add @sberdevices/plasma-ui@1.5.3-canary.318.5062609e6aa23a5c920306bb15d498a41935c1a2.0
  yarn add @sberdevices/plasma-web@1.4.2-canary.318.5062609e6aa23a5c920306bb15d498a41935c1a2.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
