### PR TITLE
fix(plasma-core): pass defaultChecked to Switch and Basebox

### DIFF
--- a/packages/plasma-core/src/components/Basebox/Basebox.tsx
+++ b/packages/plasma-core/src/components/Basebox/Basebox.tsx
@@ -231,6 +231,7 @@ export const Basebox = React.forwardRef<HTMLInputElement, BaseboxProps>(function
         label,
         description,
         checked,
+        defaultChecked,
         focused,
         disabled,
         tabIndex,
@@ -250,6 +251,7 @@ export const Basebox = React.forwardRef<HTMLInputElement, BaseboxProps>(function
                 name={name}
                 value={value}
                 checked={checked}
+                defaultChecked={defaultChecked}
                 disabled={disabled}
                 tabIndex={tabIndex}
                 onChange={onChange}

--- a/packages/plasma-core/src/components/Switch/Switch.tsx
+++ b/packages/plasma-core/src/components/Switch/Switch.tsx
@@ -129,6 +129,7 @@ export const Switch = React.forwardRef<HTMLInputElement, SwitchProps>(function S
         value,
         label,
         checked,
+        defaultChecked,
         disabled,
         pressed,
         focused,
@@ -150,6 +151,7 @@ export const Switch = React.forwardRef<HTMLInputElement, SwitchProps>(function S
                 name={name}
                 value={value}
                 checked={checked}
+                defaultChecked={defaultChecked}
                 disabled={disabled}
                 tabIndex={tabIndex}
                 onChange={onChange}


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/showcase@0.22.1-canary.338.f5cf3c7c17067c30ac39207fb7d78534b756d444.0
  npm install @sberdevices/plasma-core@1.12.1-canary.338.f5cf3c7c17067c30ac39207fb7d78534b756d444.0
  npm install @sberdevices/plasma-icons@1.15.1-canary.338.f5cf3c7c17067c30ac39207fb7d78534b756d444.0
  npm install @sberdevices/plasma-ui@1.18.1-canary.338.f5cf3c7c17067c30ac39207fb7d78534b756d444.0
  npm install @sberdevices/plasma-web@1.16.1-canary.338.f5cf3c7c17067c30ac39207fb7d78534b756d444.0
  # or 
  yarn add @sberdevices/showcase@0.22.1-canary.338.f5cf3c7c17067c30ac39207fb7d78534b756d444.0
  yarn add @sberdevices/plasma-core@1.12.1-canary.338.f5cf3c7c17067c30ac39207fb7d78534b756d444.0
  yarn add @sberdevices/plasma-icons@1.15.1-canary.338.f5cf3c7c17067c30ac39207fb7d78534b756d444.0
  yarn add @sberdevices/plasma-ui@1.18.1-canary.338.f5cf3c7c17067c30ac39207fb7d78534b756d444.0
  yarn add @sberdevices/plasma-web@1.16.1-canary.338.f5cf3c7c17067c30ac39207fb7d78534b756d444.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
