### PR TITLE
Description for checkbox and radiobox

### DIFF
--- a/docs/showcase/src/helpers/CheckboxShowcase.tsx
+++ b/docs/showcase/src/helpers/CheckboxShowcase.tsx
@@ -19,12 +19,12 @@ const elementDescription = (
 );
 const rows = [
     [
-        { ...props, name: 'check', value: 1, label: 'Checkbox 1', disabled: false },
-        { ...props, name: 'check', value: 2, label: 'Checkbox 2', disabled: false },
+        { ...props, name: 'check', value: 1, label: 'Checkbox 1', disabled: false, description: '' },
+        { ...props, name: 'check', value: 2, label: 'Checkbox 2', disabled: false, description: '' },
     ],
     [
-        { ...props, name: 'check', value: 3, label: 'Checkbox 3', disabled: true },
-        { ...props, name: 'check', value: 4, label: 'Checkbox 4', disabled: true },
+        { ...props, name: 'check', value: 3, label: 'Checkbox 3', disabled: true, description: '' },
+        { ...props, name: 'check', value: 4, label: 'Checkbox 4', disabled: true, description: '' },
     ],
     [
         { ...props, name: 'check', value: 5, label: 'Checkbox 5', disabled: false, description: 'text description' },

--- a/docs/showcase/src/helpers/CheckboxShowcase.tsx
+++ b/docs/showcase/src/helpers/CheckboxShowcase.tsx
@@ -12,6 +12,11 @@ const props = {
     onFocus,
     onBlur,
 };
+const elementDescription = (
+    <div>
+        Description with <a href="/#">link</a>
+    </div>
+);
 const rows = [
     [
         { ...props, name: 'check', value: 1, label: 'Checkbox 1', disabled: false },
@@ -20,6 +25,10 @@ const rows = [
     [
         { ...props, name: 'check', value: 3, label: 'Checkbox 3', disabled: true },
         { ...props, name: 'check', value: 4, label: 'Checkbox 4', disabled: true },
+    ],
+    [
+        { ...props, name: 'check', value: 5, label: 'Checkbox 5', disabled: false, description: 'text description' },
+        { ...props, name: 'check', value: 6, label: 'Checkbox 6', disabled: false, description: elementDescription },
     ],
 ];
 

--- a/docs/showcase/src/helpers/RadioboxShowcase.tsx
+++ b/docs/showcase/src/helpers/RadioboxShowcase.tsx
@@ -12,6 +12,11 @@ const props = {
     onFocus,
     onBlur,
 };
+const elementDescription = (
+    <div>
+        Description with <a href="/#">link</a>
+    </div>
+);
 const rows = [
     [
         { ...props, name: 'radio-1', value: 1, label: 'Radiobox 1', disabled: false, checked: false },
@@ -20,6 +25,26 @@ const rows = [
     [
         { ...props, name: 'radio-2', value: 3, label: 'Radiobox 3', disabled: true, checked: false },
         { ...props, name: 'radio-2', value: 4, label: 'Radiobox 4', disabled: true, checked: true },
+    ],
+    [
+        {
+            ...props,
+            name: 'radio-1',
+            value: 5,
+            label: 'Radiobox 5',
+            disabled: false,
+            checked: false,
+            description: 'text description',
+        },
+        {
+            ...props,
+            name: 'radio-1',
+            value: 6,
+            label: 'Radiobox 6',
+            disabled: false,
+            checked: false,
+            description: elementDescription,
+        },
     ],
 ];
 

--- a/docs/showcase/src/helpers/RadioboxShowcase.tsx
+++ b/docs/showcase/src/helpers/RadioboxShowcase.tsx
@@ -19,12 +19,12 @@ const elementDescription = (
 );
 const rows = [
     [
-        { ...props, name: 'radio-1', value: 1, label: 'Radiobox 1', disabled: false, checked: false },
-        { ...props, name: 'radio-1', value: 2, label: 'Radiobox 2', disabled: false, checked: false },
+        { ...props, name: 'radio-1', value: 1, label: 'Radiobox 1', disabled: false, checked: false, description: '' },
+        { ...props, name: 'radio-1', value: 2, label: 'Radiobox 2', disabled: false, checked: false, description: '' },
     ],
     [
-        { ...props, name: 'radio-2', value: 3, label: 'Radiobox 3', disabled: true, checked: false },
-        { ...props, name: 'radio-2', value: 4, label: 'Radiobox 4', disabled: true, checked: true },
+        { ...props, name: 'radio-2', value: 3, label: 'Radiobox 3', disabled: true, checked: false, description: '' },
+        { ...props, name: 'radio-2', value: 4, label: 'Radiobox 4', disabled: true, checked: true, description: '' },
     ],
     [
         {

--- a/packages/plasma-core/src/components/Basebox/Basebox.tsx
+++ b/packages/plasma-core/src/components/Basebox/Basebox.tsx
@@ -4,7 +4,7 @@ import styled, { css } from 'styled-components';
 import { applyDisabled } from '../../mixins';
 import type { DisabledProps, FocusProps } from '../../mixins';
 import type { InputHTMLAttributes } from '../../types';
-import { body1, accent, white, transparent, blackSecondary } from '../../tokens';
+import { body1, footnote1, accent, white, transparent, blackSecondary } from '../../tokens';
 
 import { IconDone } from './IconDone';
 
@@ -213,7 +213,7 @@ const StyledLabel = styled.span`
 `;
 
 const StyledDescription = styled.div`
-    ${body1};
+    ${footnote1};
     margin-top: 0.42rem;
     margin-left: 2rem;
     flex-basis: 100%;

--- a/packages/plasma-core/src/components/Basebox/Basebox.tsx
+++ b/packages/plasma-core/src/components/Basebox/Basebox.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import styled, { css } from 'styled-components';
 
 import { applyDisabled } from '../../mixins';
 import type { DisabledProps, FocusProps } from '../../mixins';
 import type { InputHTMLAttributes } from '../../types';
-import { body1, accent, white, transparent } from '../../tokens';
+import { body1, accent, white, transparent, blackSecondary } from '../../tokens';
 
 import { IconDone } from './IconDone';
 
@@ -22,6 +22,10 @@ export type Item = {
      * Метка-подпись к элементу
      */
     label?: string | number;
+    /**
+     * Описание элемента
+     */
+    description?: string | number | ReactNode;
 };
 
 interface InputTypeProps {
@@ -42,6 +46,7 @@ export interface BaseboxProps
 const StyledRoot = styled.label<DisabledProps>`
     position: relative;
     display: flex;
+    flex-wrap: wrap;
     width: max-content;
     max-width: 100%;
     cursor: pointer;
@@ -207,9 +212,33 @@ const StyledLabel = styled.span`
     user-select: none;
 `;
 
+const StyledDescription = styled.div`
+    ${body1};
+    margin-top: 0.42rem;
+    margin-left: 2rem;
+    flex-basis: 100%;
+    user-select: none;
+    color: ${blackSecondary};
+`;
+
 // eslint-disable-next-line prefer-arrow-callback
 export const Basebox = React.forwardRef<HTMLInputElement, BaseboxProps>(function Basebox(
-    { id, type, name, value, label, checked, focused, disabled, tabIndex, onChange, onFocus, onBlur, ...rest },
+    {
+        id,
+        type,
+        name,
+        value,
+        label,
+        description,
+        checked,
+        focused,
+        disabled,
+        tabIndex,
+        onChange,
+        onFocus,
+        onBlur,
+        ...rest
+    },
     ref,
 ) {
     return (
@@ -231,6 +260,7 @@ export const Basebox = React.forwardRef<HTMLInputElement, BaseboxProps>(function
                 {type === 'checkbox' ? <StyledMark color="inherit" size="xs" /> : <StyledEllipse />}
             </StyledTrigger>
             {label && <StyledLabel>{label}</StyledLabel>}
+            {description && <StyledDescription>{description}</StyledDescription>}
         </StyledRoot>
     );
 });

--- a/packages/plasma-ui/src/components/Basebox/Basebox.tsx
+++ b/packages/plasma-ui/src/components/Basebox/Basebox.tsx
@@ -8,7 +8,7 @@ import type { InteractionProps } from '../../mixins';
 /**
  * Input-type agnostic mixin for "boolean" inputs.
  */
-export const basebox: InterpolationFunction<Omit<BaseboxProps, 'type'> & InteractionProps> = ({
+export const basebox: InterpolationFunction<Omit<BaseboxProps, 'type' | 'description'> & InteractionProps> = ({
     scaleOnInteraction,
 }) => css`
     --plasma-basebox-trigger-border: ${secondary};

--- a/packages/plasma-web/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/plasma-web/src/components/Checkbox/Checkbox.stories.tsx
@@ -36,3 +36,52 @@ export const Default = () => {
         />
     );
 };
+
+export const TextDescription = () => {
+    const value = 0;
+    const [checked, setChecked] = React.useState(true);
+
+    return (
+        <Checkbox
+            name={text('name', 'checkbox')}
+            value={value}
+            label={text('label', 'Label')}
+            description={text('description', 'Description')}
+            disabled={boolean('disabled', false)}
+            checked={checked}
+            onChange={(event) => {
+                setChecked(event.target.checked);
+                onChange(event);
+            }}
+            onFocus={onFocus}
+            onBlur={onBlur}
+        />
+    );
+};
+
+export const NodeDescription = () => {
+    const value = 0;
+    const [checked, setChecked] = React.useState(true);
+    const description = (
+        <div>
+            Description with <a href="/#">link</a>{' '}
+        </div>
+    );
+
+    return (
+        <Checkbox
+            name={text('name', 'checkbox')}
+            value={value}
+            label={text('label', 'Label')}
+            description={description}
+            disabled={boolean('disabled', false)}
+            checked={checked}
+            onChange={(event) => {
+                setChecked(event.target.checked);
+                onChange(event);
+            }}
+            onFocus={onFocus}
+            onBlur={onBlur}
+        />
+    );
+};

--- a/packages/plasma-web/src/components/Radiobox/Radiobox.stories.tsx
+++ b/packages/plasma-web/src/components/Radiobox/Radiobox.stories.tsx
@@ -36,3 +36,52 @@ export const Default = () => {
         />
     );
 };
+
+export const TextDescription = () => {
+    const value = 0;
+    const [checked, setChecked] = React.useState(true);
+
+    return (
+        <Radiobox
+            name={text('name', 'Radiobox')}
+            value={value}
+            label={text('label', 'Label')}
+            description={text('description', 'Description')}
+            disabled={boolean('disabled', false)}
+            checked={checked}
+            onChange={(event) => {
+                setChecked(event.target.checked);
+                onChange(event);
+            }}
+            onFocus={onFocus}
+            onBlur={onBlur}
+        />
+    );
+};
+
+export const NodeDescription = () => {
+    const value = 0;
+    const [checked, setChecked] = React.useState(true);
+    const description = (
+        <div>
+            Description with <a href="/#">link</a>{' '}
+        </div>
+    );
+
+    return (
+        <Radiobox
+            name={text('name', 'Radiobox')}
+            value={value}
+            label={text('label', 'Label')}
+            description={description}
+            disabled={boolean('disabled', false)}
+            checked={checked}
+            onChange={(event) => {
+                setChecked(event.target.checked);
+                onChange(event);
+            }}
+            onFocus={onFocus}
+            onBlur={onBlur}
+        />
+    );
+};


### PR DESCRIPTION
Добавил возможность размещения подписи для компонентов Checkbox и Radiobox.
Серый фон для самого активного элемента не нужен, т. к. это цвет карточки внутри которой лежит радиобокс.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/showcase@0.16.0-canary.347.1413cd02f0eb5734c4a83abd5f725f2b0eb132ed.0
  npm install @sberdevices/plasma-core@1.8.0-canary.347.1413cd02f0eb5734c4a83abd5f725f2b0eb132ed.0
  npm install @sberdevices/plasma-icons@1.9.0-canary.347.1413cd02f0eb5734c4a83abd5f725f2b0eb132ed.0
  npm install @sberdevices/plasma-ui@1.12.0-canary.347.1413cd02f0eb5734c4a83abd5f725f2b0eb132ed.0
  npm install @sberdevices/plasma-web@1.10.0-canary.347.1413cd02f0eb5734c4a83abd5f725f2b0eb132ed.0
  # or 
  yarn add @sberdevices/showcase@0.16.0-canary.347.1413cd02f0eb5734c4a83abd5f725f2b0eb132ed.0
  yarn add @sberdevices/plasma-core@1.8.0-canary.347.1413cd02f0eb5734c4a83abd5f725f2b0eb132ed.0
  yarn add @sberdevices/plasma-icons@1.9.0-canary.347.1413cd02f0eb5734c4a83abd5f725f2b0eb132ed.0
  yarn add @sberdevices/plasma-ui@1.12.0-canary.347.1413cd02f0eb5734c4a83abd5f725f2b0eb132ed.0
  yarn add @sberdevices/plasma-web@1.10.0-canary.347.1413cd02f0eb5734c4a83abd5f725f2b0eb132ed.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
