### PR TITLE
Fix carousel slot and carousel/pickers animation with delay

### DIFF
--- a/docs/showcase/src/ui/Carousel.stories.tsx
+++ b/docs/showcase/src/ui/Carousel.stories.tsx
@@ -21,6 +21,7 @@ export default {
     title: 'UI/Controls/Carousel',
     component: Carousel,
     decorators: [UIStoryDecorator],
+    chromatic: { delay: 700 },
 };
 
 const items = Array(25)
@@ -285,7 +286,3 @@ export const Default = () => (
         <ScaledCentralItem />
     </Container>
 );
-
-Default.parameters = {
-    chromatic: { pauseAnimationAtEnd: true },
-};

--- a/docs/showcase/src/ui/Pickers.stories.tsx
+++ b/docs/showcase/src/ui/Pickers.stories.tsx
@@ -13,6 +13,7 @@ import { ShowcaseDashedBorder, ShowcaseHead, UIStoryDecorator, InSpacingDecorato
 export default {
     title: 'UI/Controls/Pickers',
     decorators: [UIStoryDecorator, InSpacingDecorator],
+    chromatic: { delay: 700 },
 };
 
 const now = new Date();
@@ -110,7 +111,3 @@ export const Default = () => (
         </StyledRow>
     </>
 );
-
-Default.parameters = {
-    chromatic: { pauseAnimationAtEnd: true },
-};

--- a/packages/plasma-ui/package-lock.json
+++ b/packages/plasma-ui/package-lock.json
@@ -13332,7 +13332,7 @@
         },
         "babel-plugin-add-react-displayname": {
             "version": "0.0.5",
-            "resolved": "https://registry.npmjs.org/babel-plugin-add-react-displayname/-/babel-plugin-add-react-displayname-0.0.5.tgz",
+            "resolved": false,
             "integrity": "sha1-M51M3be2X9YtHfnbn+BN4TQSK9U=",
             "dev": true
         },

--- a/packages/plasma-ui/src/components/Carousel/Carousel.tsx
+++ b/packages/plasma-ui/src/components/Carousel/Carousel.tsx
@@ -428,7 +428,7 @@ export const Carousel = React.forwardRef<HTMLDivElement, CarouselProps>(function
                     itemIndex,
                 });
 
-                if (itemSlot) {
+                if (itemSlot !== null) {
                     if (detectThreshold && Math.abs(itemSlot) <= detectThreshold) {
                         debouncedOnIndexChange(itemIndex);
                     }


### PR DESCRIPTION
Должно помочь с лагающими каруселями в скриншотах
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/showcase@0.15.1-canary.349.fbd545fdf25fdf7b4cfbf7a797a89a0db7862b69.0
  npm install @sberdevices/plasma-core@1.7.1-canary.349.fbd545fdf25fdf7b4cfbf7a797a89a0db7862b69.0
  npm install @sberdevices/plasma-icons@1.8.1-canary.349.fbd545fdf25fdf7b4cfbf7a797a89a0db7862b69.0
  npm install @sberdevices/plasma-ui@1.11.1-canary.349.fbd545fdf25fdf7b4cfbf7a797a89a0db7862b69.0
  npm install @sberdevices/plasma-web@1.9.1-canary.349.fbd545fdf25fdf7b4cfbf7a797a89a0db7862b69.0
  # or 
  yarn add @sberdevices/showcase@0.15.1-canary.349.fbd545fdf25fdf7b4cfbf7a797a89a0db7862b69.0
  yarn add @sberdevices/plasma-core@1.7.1-canary.349.fbd545fdf25fdf7b4cfbf7a797a89a0db7862b69.0
  yarn add @sberdevices/plasma-icons@1.8.1-canary.349.fbd545fdf25fdf7b4cfbf7a797a89a0db7862b69.0
  yarn add @sberdevices/plasma-ui@1.11.1-canary.349.fbd545fdf25fdf7b4cfbf7a797a89a0db7862b69.0
  yarn add @sberdevices/plasma-web@1.9.1-canary.349.fbd545fdf25fdf7b4cfbf7a797a89a0db7862b69.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
