### PR TITLE
fix(plasma-ui): fix simultaneous src&placeholder display

### DIFF
--- a/packages/plasma-ui/src/components/Card/CardMedia.tsx
+++ b/packages/plasma-ui/src/components/Card/CardMedia.tsx
@@ -35,7 +35,7 @@ export const CardMedia: React.FC<CardMediaProps> = ({
 }) => {
     const imgStyle: React.CSSProperties = { ...style };
 
-    if (placeholder) {
+    if (placeholder && !props.src) {
         imgStyle.backgroundImage = `url('${placeholder}')`;
     }
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/showcase@0.18.1-canary.390.881265e8ce9ea18778d05548637b92a4b4e1824b.0
  npm install @sberdevices/plasma-icons@1.11.1-canary.390.881265e8ce9ea18778d05548637b92a4b4e1824b.0
  npm install @sberdevices/plasma-ui@1.14.1-canary.390.881265e8ce9ea18778d05548637b92a4b4e1824b.0
  npm install @sberdevices/plasma-web@1.12.1-canary.390.881265e8ce9ea18778d05548637b92a4b4e1824b.0
  # or 
  yarn add @sberdevices/showcase@0.18.1-canary.390.881265e8ce9ea18778d05548637b92a4b4e1824b.0
  yarn add @sberdevices/plasma-icons@1.11.1-canary.390.881265e8ce9ea18778d05548637b92a4b4e1824b.0
  yarn add @sberdevices/plasma-ui@1.14.1-canary.390.881265e8ce9ea18778d05548637b92a4b4e1824b.0
  yarn add @sberdevices/plasma-web@1.12.1-canary.390.881265e8ce9ea18778d05548637b92a4b4e1824b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
