### PR TITLE
feat: short month name in datepicker

### DIFF
--- a/docs/showcase/src/ui/Pickers.stories.tsx
+++ b/docs/showcase/src/ui/Pickers.stories.tsx
@@ -13,7 +13,7 @@ import { ShowcaseDashedBorder, ShowcaseHead, UIStoryDecorator, InSpacingDecorato
 
 export default {
     title: 'UI/Controls/Pickers',
-    decorators: [UIStoryDecorator, InSpacingDecorator],
+    decorators: [UIStoryDecorator, InSpacingDecorator, withKnobs],
     chromatic: { delay: 700 },
 };
 

--- a/docs/showcase/src/ui/Pickers.stories.tsx
+++ b/docs/showcase/src/ui/Pickers.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { action } from '@storybook/addon-actions';
+import { withKnobs, boolean } from '@storybook/addon-knobs';
 import {
     DatePicker as DatePickerComponent,
     DatePickerProps,
@@ -45,6 +46,7 @@ const DatePicker: React.FC<Omit<DatePickerProps, 'value' | 'max' | 'min'>> = (pr
                 years: true,
                 months: true,
                 days: true,
+                shortMonthName: boolean('options.shortMonthName', false),
             }}
             visibleItems={5}
             onChange={(val) => {

--- a/packages/plasma-core/src/utils/formatters.ts
+++ b/packages/plasma-core/src/utils/formatters.ts
@@ -10,8 +10,13 @@ export const padZeroNumber = (value: number) => `${value}`.padStart(2, '0');
  * в котором находятся части даты, форматированной на основнии `options`.
  * То есть в данном случае вернется массив [`day`, `separator`, `month`]
  */
-export const monthLongName = (val: number): string =>
-    last(new Intl.DateTimeFormat('ru-RU', { day: 'numeric', month: 'long' }).formatToParts(new Date().setMonth(val)))
-        .value;
+export const monthName = (val: number, monthFormat: Intl.DateTimeFormatOptions['month']): string =>
+    last(
+        new Intl.DateTimeFormat('ru-RU', { day: 'numeric', month: monthFormat }).formatToParts(
+            new Date().setMonth(val),
+        ),
+    ).value;
 
-export const monthShortName = (val: number): string => monthLongName(val).substring(0, 3);
+export const monthLongName = (val: number): string => monthName(val, 'long');
+
+export const monthShortName = (val: number): string => monthName(val, 'short').slice(0, -1);

--- a/packages/plasma-core/src/utils/formatters.ts
+++ b/packages/plasma-core/src/utils/formatters.ts
@@ -19,4 +19,4 @@ export const monthName = (val: number, monthFormat: Intl.DateTimeFormatOptions['
 
 export const monthLongName = (val: number): string => monthName(val, 'long');
 
-export const monthShortName = (val: number): string => monthName(val, 'short').slice(0, -1);
+export const monthShortName = (val: number): string => monthName(val, 'short').replace('.', '');

--- a/packages/plasma-core/src/utils/formatters.ts
+++ b/packages/plasma-core/src/utils/formatters.ts
@@ -13,3 +13,5 @@ export const padZeroNumber = (value: number) => `${value}`.padStart(2, '0');
 export const monthLongName = (val: number): string =>
     last(new Intl.DateTimeFormat('ru-RU', { day: 'numeric', month: 'long' }).formatToParts(new Date().setMonth(val)))
         .value;
+
+export const monthShortName = (val: number): string => monthLongName(val).substring(0, 3);

--- a/packages/plasma-core/src/utils/index.ts
+++ b/packages/plasma-core/src/utils/index.ts
@@ -4,7 +4,7 @@ export type { TimingFunction } from './animatedScrollTo';
 export { convertRoundnessMatrix } from './roundness';
 export type { PinProps } from './roundness';
 
-export { padZeroNumber, monthLongName } from './formatters';
+export { padZeroNumber, monthLongName, monthShortName } from './formatters';
 export { formatCurrency } from './formatCurrency';
 
 export {

--- a/packages/plasma-ui/src/components/Pickers/DatePicker.tsx
+++ b/packages/plasma-ui/src/components/Pickers/DatePicker.tsx
@@ -160,11 +160,13 @@ export const DatePicker: React.FC<DatePickerProps> = ({
         }
     }, [year, month, day]);
 
-    const daysOption = typeof options.days === 'boolean' ? options.days : defaultOptions.days;
-    const monthsOption = typeof options.months === 'boolean' ? options.months : defaultOptions.months;
-    const yearsOption = typeof options.years === 'boolean' ? options.years : defaultOptions.years;
-    const shortMonthNameOption =
-        typeof options.shortMonthName === 'boolean' ? options.shortMonthName : defaultOptions.shortMonthName;
+    const getOption = (key: keyof typeof defaultOptions) =>
+        typeof options[key] === 'boolean' ? options[key] : defaultOptions[key];
+
+    const daysOption = getOption('days');
+    const monthsOption = getOption('months');
+    const yearsOption = getOption('years');
+    const shortMonthNameOption = getOption('shortMonthName');
     const monthNameFormat = shortMonthNameOption ? 'short' : 'long';
     return (
         <StyledWrapper>

--- a/packages/plasma-ui/src/components/Pickers/DatePicker.tsx
+++ b/packages/plasma-ui/src/components/Pickers/DatePicker.tsx
@@ -160,8 +160,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
         }
     }, [year, month, day]);
 
-    const getOption = (key: keyof typeof defaultOptions) =>
-        typeof options[key] === 'boolean' ? options[key] : defaultOptions[key];
+    const getOption = (key: keyof typeof defaultOptions) => (key in options ? options[key] : defaultOptions[key]);
 
     const daysOption = getOption('days');
     const monthsOption = getOption('months');

--- a/packages/plasma-ui/src/components/Pickers/DatePicker.tsx
+++ b/packages/plasma-ui/src/components/Pickers/DatePicker.tsx
@@ -9,6 +9,7 @@ const defaultOptions = {
     years: true,
     months: true,
     days: true,
+    shortMonthName: false,
 };
 
 const StyledWrapper = styled.div`
@@ -36,7 +37,7 @@ export interface DatePickerProps extends Omit<SimpleDatePickerProps, 'type' | 'f
     /**
      * Формат выводимого значения
      */
-    options?: typeof defaultOptions;
+    options?: Partial<typeof defaultOptions>;
 }
 
 /**
@@ -159,9 +160,15 @@ export const DatePicker: React.FC<DatePickerProps> = ({
         }
     }, [year, month, day]);
 
+    const daysOption = typeof options.days === 'boolean' ? options.days : defaultOptions.days;
+    const monthsOption = typeof options.months === 'boolean' ? options.months : defaultOptions.months;
+    const yearsOption = typeof options.years === 'boolean' ? options.years : defaultOptions.years;
+    const shortMonthNameOption =
+        typeof options.shortMonthName === 'boolean' ? options.shortMonthName : defaultOptions.shortMonthName;
+    const monthNameFormat = shortMonthNameOption ? 'short' : 'long';
     return (
         <StyledWrapper>
-            {options.days && (
+            {daysOption && (
                 <SimpleDatePicker
                     autofocus={autofocus}
                     size={size}
@@ -175,11 +182,12 @@ export const DatePicker: React.FC<DatePickerProps> = ({
                     onChange={onDayChange}
                 />
             )}
-            {options.months && (
+            {monthsOption && (
                 <SimpleDatePicker
                     autofocus={autofocus && !options.days}
                     size={size}
                     type="month"
+                    monthNameFormat={monthNameFormat}
                     value={month}
                     from={monthsInterval[0]}
                     to={monthsInterval[1]}
@@ -189,7 +197,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
                     onChange={onMonthChange}
                 />
             )}
-            {options.years && (
+            {yearsOption && (
                 <SimpleDatePicker
                     autofocus={autofocus && !options.days && !options.months}
                     size={size}

--- a/packages/plasma-ui/src/components/Pickers/Pickers.stories.tsx
+++ b/packages/plasma-ui/src/components/Pickers/Pickers.stories.tsx
@@ -27,6 +27,7 @@ export const DatePicker = () => {
                 years: boolean('options.years', true),
                 months: boolean('options.months', true),
                 days: boolean('options.days', true),
+                shortMonthName: boolean('options.shortMonthName', false),
             }}
             disabled={boolean('disabled', false)}
             controls={boolean('controls', isSberbox)}

--- a/packages/plasma-ui/src/components/Pickers/SimpleDatePicker.tsx
+++ b/packages/plasma-ui/src/components/Pickers/SimpleDatePicker.tsx
@@ -15,7 +15,7 @@ const labelFormatter = {
 
 const getFormatterKey = (type: PickerType, monthNameFormat?: MonthNameFormat): keyof typeof labelFormatter => {
     const isMonth = type === 'month';
-    const isShortFormat = monthNameFormat && monthNameFormat === 'short';
+    const isShortFormat = monthNameFormat === 'short';
     if (isMonth && isShortFormat) {
         return 'monthShort';
     }

--- a/packages/plasma-ui/src/components/Pickers/SimpleDatePicker.tsx
+++ b/packages/plasma-ui/src/components/Pickers/SimpleDatePicker.tsx
@@ -1,24 +1,37 @@
 import React from 'react';
-import { monthShortName } from '@sberdevices/plasma-core';
+import { monthShortName, monthLongName } from '@sberdevices/plasma-core';
 
 import { Picker, PickerProps } from './Picker';
 
 type PickerType = 'day' | 'month' | 'year';
+type MonthNameFormat = 'long' | 'short';
 
 const labelFormatter = {
     day: (value: number) => `${value}`,
     year: (value: number) => `${value}`,
-    month: monthShortName,
+    month: monthLongName,
+    monthShort: monthShortName,
+};
+
+const getFormatterKey = (type: PickerType, monthNameFormat?: MonthNameFormat): keyof typeof labelFormatter => {
+    const isMonth = type === 'month';
+    const isShortFormat = monthNameFormat && monthNameFormat === 'short';
+    if (isMonth && isShortFormat) {
+        return 'monthShort';
+    }
+    return type;
 };
 
 export interface SimpleDatePickerProps extends Omit<PickerProps, 'items'> {
     from: number;
     to: number;
     type: PickerType;
+    monthNameFormat?: MonthNameFormat;
 }
 
-export const SimpleDatePicker: React.FC<SimpleDatePickerProps> = ({ type, from, to, ...rest }) => {
-    const formatter = labelFormatter[type];
+export const SimpleDatePicker: React.FC<SimpleDatePickerProps> = ({ type, from, to, monthNameFormat, ...rest }) => {
+    const formatterKey = getFormatterKey(type, monthNameFormat);
+    const formatter = labelFormatter[formatterKey];
 
     const items = Array.from({ length: to - from + 1 }, (_, i) => ({
         label: formatter(from + i),

--- a/packages/plasma-ui/src/components/Pickers/SimpleDatePicker.tsx
+++ b/packages/plasma-ui/src/components/Pickers/SimpleDatePicker.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { monthLongName } from '@sberdevices/plasma-core';
+import { monthShortName } from '@sberdevices/plasma-core';
 
 import { Picker, PickerProps } from './Picker';
 
@@ -8,7 +8,7 @@ type PickerType = 'day' | 'month' | 'year';
 const labelFormatter = {
     day: (value: number) => `${value}`,
     year: (value: number) => `${value}`,
-    month: monthLongName,
+    month: monthShortName,
 };
 
 export interface SimpleDatePickerProps extends Omit<PickerProps, 'items'> {


### PR DESCRIPTION
В DatePicker на plasma-ui месяц теперь отображается с коротким названием:
<img width="458" alt="Снимок экрана 2021-05-14 в 17 29 07" src="https://user-images.githubusercontent.com/19724906/118286248-f0c14400-b4da-11eb-82ab-ddeada6996ca.png">


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/showcase@0.22.0-canary.392.cb38688a3ec9d39b5bd3af7007297e8336b72df5.0
  npm install @sberdevices/plasma-core@1.12.0-canary.392.cb38688a3ec9d39b5bd3af7007297e8336b72df5.0
  npm install @sberdevices/plasma-icons@1.15.0-canary.392.cb38688a3ec9d39b5bd3af7007297e8336b72df5.0
  npm install @sberdevices/plasma-ui@1.18.0-canary.392.cb38688a3ec9d39b5bd3af7007297e8336b72df5.0
  npm install @sberdevices/plasma-web@1.16.0-canary.392.cb38688a3ec9d39b5bd3af7007297e8336b72df5.0
  npm install @sberdevices/plasma-tokens-android@2.7.0-canary.392.cb38688a3ec9d39b5bd3af7007297e8336b72df5.0
  npm install @sberdevices/plasma-tokens-ios-swift@2.7.0-canary.392.cb38688a3ec9d39b5bd3af7007297e8336b72df5.0
  # or 
  yarn add @sberdevices/showcase@0.22.0-canary.392.cb38688a3ec9d39b5bd3af7007297e8336b72df5.0
  yarn add @sberdevices/plasma-core@1.12.0-canary.392.cb38688a3ec9d39b5bd3af7007297e8336b72df5.0
  yarn add @sberdevices/plasma-icons@1.15.0-canary.392.cb38688a3ec9d39b5bd3af7007297e8336b72df5.0
  yarn add @sberdevices/plasma-ui@1.18.0-canary.392.cb38688a3ec9d39b5bd3af7007297e8336b72df5.0
  yarn add @sberdevices/plasma-web@1.16.0-canary.392.cb38688a3ec9d39b5bd3af7007297e8336b72df5.0
  yarn add @sberdevices/plasma-tokens-android@2.7.0-canary.392.cb38688a3ec9d39b5bd3af7007297e8336b72df5.0
  yarn add @sberdevices/plasma-tokens-ios-swift@2.7.0-canary.392.cb38688a3ec9d39b5bd3af7007297e8336b72df5.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
