### PR TITLE
fix(plasma-tokens): backward compatibility

### DIFF
--- a/packages/plasma-tokens/generate.ts
+++ b/packages/plasma-tokens/generate.ts
@@ -22,9 +22,14 @@ const OUT_DIR = 'src';
 const COLORS_DIR = path.join(OUT_DIR, 'colors');
 const THEMES_DIR = path.join(OUT_DIR, 'themes');
 const THEMES_VALUES_DIR = path.join(OUT_DIR, 'themesValues');
+// TODO: REMOVE in major
+const THEMES_DIR_OLD = path.join('themes');
+const THEMES_VALUES_DIR_OLD = path.join('themesValues');
 const TYPOGRAPHY_DIR = path.join(OUT_DIR, 'typography');
 const TYPOGRAPHY_VALUES_DIR = path.join(OUT_DIR, 'typographyValues');
 const TYPO_DIR = path.join(OUT_DIR, 'typo');
+// TODO: REMOVE in major
+const TYPO_DIR_OLD = path.join('typo');
 const ROOT_INDEX_TS = path.join(OUT_DIR, 'index.ts');
 
 fs.existsSync(OUT_DIR) || fs.mkdirSync(OUT_DIR);
@@ -43,9 +48,11 @@ writeGeneratedToFS(COLORS_DIR, [
 
 // Генерация и запись файлов тем для создания глобальных стилей
 writeGeneratedToFS(THEMES_DIR, generateThemes(themes, 'cssobject', true));
+writeGeneratedToFS(THEMES_DIR_OLD, generateThemes(themes, 'cssobject', true));
 
 // Отдельные файлы для импорта в компонентах
 writeGeneratedToFS(THEMES_VALUES_DIR, generateThemes(themes, 'tokens', false));
+writeGeneratedToFS(THEMES_VALUES_DIR_OLD, generateThemes(themes, 'tokens', false));
 
 /** =================================================== **/
 /** ========= Генерация типографической сетки ========= **/
@@ -60,6 +67,14 @@ writeGeneratedToFS(TYPOGRAPHY_VALUES_DIR, generateTypographyValues(typoSystem));
 // Типографика по типам устройств для создания глобального стиля
 writeGeneratedToFS(
     TYPO_DIR,
+    generateTypo({
+        sberBox: createTypoStyles(typoSystem, deviceScales.sberBox),
+        sberPortal: createTypoStyles(typoSystem, deviceScales.sberPortal),
+        mobile: createTypoStyles(typoSystem, deviceScales.mobile),
+    }),
+);
+writeGeneratedToFS(
+    TYPO_DIR_OLD,
     generateTypo({
         sberBox: createTypoStyles(typoSystem, deviceScales.sberBox),
         sberPortal: createTypoStyles(typoSystem, deviceScales.sberPortal),

--- a/packages/plasma-tokens/package.json
+++ b/packages/plasma-tokens/package.json
@@ -27,6 +27,7 @@
     },
     "files": [
         "lib",
+        "es",
         "typo",
         "themes",
         "themesValues",


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/showcase@0.21.1-canary.419.9a1f60abeeccd399dfc2bce83a3aef9249f07dab.0
  npm install @sberdevices/plasma-tokens@1.5.1-canary.419.9a1f60abeeccd399dfc2bce83a3aef9249f07dab.0
  npm install @sberdevices/plasma-ui@1.17.1-canary.419.9a1f60abeeccd399dfc2bce83a3aef9249f07dab.0
  npm install @sberdevices/plasma-web@1.15.1-canary.419.9a1f60abeeccd399dfc2bce83a3aef9249f07dab.0
  npm install @sberdevices/plasma-tokens-android@2.6.1-canary.419.9a1f60abeeccd399dfc2bce83a3aef9249f07dab.0
  npm install @sberdevices/plasma-tokens-ios-swift@2.6.1-canary.419.9a1f60abeeccd399dfc2bce83a3aef9249f07dab.0
  # or 
  yarn add @sberdevices/showcase@0.21.1-canary.419.9a1f60abeeccd399dfc2bce83a3aef9249f07dab.0
  yarn add @sberdevices/plasma-tokens@1.5.1-canary.419.9a1f60abeeccd399dfc2bce83a3aef9249f07dab.0
  yarn add @sberdevices/plasma-ui@1.17.1-canary.419.9a1f60abeeccd399dfc2bce83a3aef9249f07dab.0
  yarn add @sberdevices/plasma-web@1.15.1-canary.419.9a1f60abeeccd399dfc2bce83a3aef9249f07dab.0
  yarn add @sberdevices/plasma-tokens-android@2.6.1-canary.419.9a1f60abeeccd399dfc2bce83a3aef9249f07dab.0
  yarn add @sberdevices/plasma-tokens-ios-swift@2.6.1-canary.419.9a1f60abeeccd399dfc2bce83a3aef9249f07dab.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
