### PR TITLE
fix(plasma-core): remove focus on click in button

### DIFF
--- a/packages/plasma-core/package-lock.json
+++ b/packages/plasma-core/package-lock.json
@@ -12863,6 +12863,11 @@
                 "readable-stream": "^2.3.6"
             }
         },
+        "focus-visible": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.2.0.tgz",
+            "integrity": "sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ=="
+        },
         "follow-redirects": {
             "version": "1.5.10",
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",

--- a/packages/plasma-core/package.json
+++ b/packages/plasma-core/package.json
@@ -79,6 +79,7 @@
     ],
     "sideEffects": false,
     "dependencies": {
+        "focus-visible": "5.2.0",
         "lodash.throttle": "4.1.1"
     }
 }

--- a/packages/plasma-core/src/mixins/addFocus.ts
+++ b/packages/plasma-core/src/mixins/addFocus.ts
@@ -2,6 +2,8 @@ import { css, FlattenSimpleInterpolation, InterpolationFunction } from 'styled-c
 
 import { buttonFocused } from '../tokens';
 
+import 'focus-visible';
+
 export interface FocusProps {
     /**
      * Компонент в фокусе
@@ -42,7 +44,8 @@ interface OutlineProps {
 }
 
 export const syntheticFocus: SynthesizeFocus = (ruleset, focused) => css`
-    &:focus {
+    &.focus-visible:focus {
+        outline: none;
         ${ruleset}
     }
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/showcase@0.23.1-canary.437.73f888aa2f534f6b3c7533d430b475877b006191.0
  npm install @sberdevices/plasma-core@1.12.2-canary.437.73f888aa2f534f6b3c7533d430b475877b006191.0
  npm install @sberdevices/plasma-icons@1.16.1-canary.437.73f888aa2f534f6b3c7533d430b475877b006191.0
  npm install @sberdevices/plasma-tokens-web@1.5.1-canary.437.73f888aa2f534f6b3c7533d430b475877b006191.0
  npm install @sberdevices/plasma-tokens@1.6.1-canary.437.73f888aa2f534f6b3c7533d430b475877b006191.0
  npm install @sberdevices/plasma-ui@1.19.1-canary.437.73f888aa2f534f6b3c7533d430b475877b006191.0
  npm install @sberdevices/plasma-web@1.17.1-canary.437.73f888aa2f534f6b3c7533d430b475877b006191.0
  npm install @sberdevices/plasma-tokens-android@2.8.1-canary.437.73f888aa2f534f6b3c7533d430b475877b006191.0
  npm install @sberdevices/plasma-tokens-ios-swift@2.8.1-canary.437.73f888aa2f534f6b3c7533d430b475877b006191.0
  # or 
  yarn add @sberdevices/showcase@0.23.1-canary.437.73f888aa2f534f6b3c7533d430b475877b006191.0
  yarn add @sberdevices/plasma-core@1.12.2-canary.437.73f888aa2f534f6b3c7533d430b475877b006191.0
  yarn add @sberdevices/plasma-icons@1.16.1-canary.437.73f888aa2f534f6b3c7533d430b475877b006191.0
  yarn add @sberdevices/plasma-tokens-web@1.5.1-canary.437.73f888aa2f534f6b3c7533d430b475877b006191.0
  yarn add @sberdevices/plasma-tokens@1.6.1-canary.437.73f888aa2f534f6b3c7533d430b475877b006191.0
  yarn add @sberdevices/plasma-ui@1.19.1-canary.437.73f888aa2f534f6b3c7533d430b475877b006191.0
  yarn add @sberdevices/plasma-web@1.17.1-canary.437.73f888aa2f534f6b3c7533d430b475877b006191.0
  yarn add @sberdevices/plasma-tokens-android@2.8.1-canary.437.73f888aa2f534f6b3c7533d430b475877b006191.0
  yarn add @sberdevices/plasma-tokens-ios-swift@2.8.1-canary.437.73f888aa2f534f6b3c7533d430b475877b006191.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
