### PR TITLE
fix(plasma-ui): PickerItem sizes

### DIFF
--- a/packages/plasma-ui/package-lock.json
+++ b/packages/plasma-ui/package-lock.json
@@ -4841,9 +4841,9 @@
             }
         },
         "@sberdevices/plasma-icons": {
-            "version": "1.16.1",
-            "resolved": "https://registry.npmjs.org/@sberdevices/plasma-icons/-/plasma-icons-1.16.1.tgz",
-            "integrity": "sha512-JK3fWIpnz2fKAotp76L7j3q6sPLY/bAolU9WoRlbNlTYIaOYmlDjPmIuwy4/CMMpxvQUiqUuK3PYF9N4J10zgg==",
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/@sberdevices/plasma-icons/-/plasma-icons-1.17.0.tgz",
+            "integrity": "sha512-0lYggKuLvCr4l4mRdFHtXfloJcWrdRyXr12DbKD0DY4joKl1cJH6eglvPikix7iXLDZifzafy0NFUNs4vzVqSw==",
             "dev": true
         },
         "@sberdevices/plasma-tokens": {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/showcase@0.26.1-canary.458.9bd2c56123113189405f30d3daa58891527dcccf.0
  npm install @sberdevices/plasma-ui@1.22.1-canary.458.9bd2c56123113189405f30d3daa58891527dcccf.0
  # or 
  yarn add @sberdevices/showcase@0.26.1-canary.458.9bd2c56123113189405f30d3daa58891527dcccf.0
  yarn add @sberdevices/plasma-ui@1.22.1-canary.458.9bd2c56123113189405f30d3daa58891527dcccf.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
