### PR TITLE
fix(plasma-ui): Header back button outline indent

### DIFF
--- a/packages/plasma-ui/src/components/Header/HeaderBack.tsx
+++ b/packages/plasma-ui/src/components/Header/HeaderBack.tsx
@@ -12,7 +12,7 @@ const StyledHeaderBackButton = styled(Button)`
         position: absolute;
         /* От паддинга отнимаем сдвиг на разницу между button="s" (40) и высотой шапки (от 28 до 36) */
         top: calc(var(--plasma-header-pt) - (2.5rem - var(--plasma-header-height)) / 2);
-        left: calc(var(--plasma-grid-margin) * -1 + ${16 / scalingPixelBasis}rem);
+        left: calc(var(--plasma-grid-margin) * -1 + ${12 / scalingPixelBasis}rem);
         padding: 0;
 
         ${({ theme }) =>


### PR DESCRIPTION
В хедере обводка кнопки назад наезжает на заголовок

До
![image](https://user-images.githubusercontent.com/2942698/124753473-b485ef00-df31-11eb-89db-015d2f718145.png)
После
![image](https://user-images.githubusercontent.com/2942698/124754071-73daa580-df32-11eb-9e51-39b0f1ac4fae.png)
