### PR TITLE
Plasma UI fix time picker doc

### DIFF
--- a/packages/plasma-ui/src/components/Pickers/Pickers.stories.tsx
+++ b/packages/plasma-ui/src/components/Pickers/Pickers.stories.tsx
@@ -41,7 +41,12 @@ export const DatePicker = () => {
 
 export const TimePicker = () => {
     const [value, setValue] = React.useState(
-        new Date(now.getFullYear(), now.getMonth(), now.getDate(), ...text('value', '0:28:59').split(':').map(Number)),
+        new Date(
+            now.getFullYear(),
+            now.getMonth(),
+            now.getDate(),
+            ...text('value', '0:28:59', 'TimePicker').split(':').map(Number),
+        ),
     );
     const isSberbox = isSberBox();
 
@@ -53,7 +58,7 @@ export const TimePicker = () => {
                     now.getFullYear(),
                     now.getMonth(),
                     now.getDate(),
-                    ...text('min', '0:15:29').split(':').map(Number),
+                    ...text('min', '0:15:29', 'TimePicker').split(':').map(Number),
                 )
             }
             max={
@@ -61,20 +66,20 @@ export const TimePicker = () => {
                     now.getFullYear(),
                     now.getMonth(),
                     now.getDate(),
-                    ...text('max', '12:45:50').split(':').map(Number),
+                    ...text('max', '12:45:50', 'TimePicker').split(':').map(Number),
                 )
             }
-            step={number('step', 1)}
-            size={select('size', ['l', 's'], 'l')}
-            visibleItems={select('visibleItems', [3, 5], 3)}
+            step={number('step', 1, undefined, 'TimePicker')}
+            size={select('size', ['l', 's'], 'l', 'TimePicker')}
+            visibleItems={select('visibleItems', [3, 5], 3, 'TimePicker')}
             options={{
-                hours: boolean('options.hours', true),
-                minutes: boolean('options.minutes', true),
-                seconds: boolean('options.seconds', true),
+                hours: boolean('options.hours', true, 'TimePicker'),
+                minutes: boolean('options.minutes', true, 'TimePicker'),
+                seconds: boolean('options.seconds', true, 'TimePicker'),
             }}
-            disabled={boolean('disabled', false)}
-            controls={boolean('controls', isSberbox)}
-            autofocus={boolean('autofocus', true)}
+            disabled={boolean('disabled', false, 'TimePicker')}
+            controls={boolean('controls', isSberbox, 'TimePicker')}
+            autofocus={boolean('autofocus', true, 'TimePicker')}
             onChange={(val) => {
                 setValue(val);
                 action('onChange')(val);

--- a/packages/plasma-ui/src/components/Pickers/Pickers.stories.tsx
+++ b/packages/plasma-ui/src/components/Pickers/Pickers.stories.tsx
@@ -79,7 +79,7 @@ export const TimePicker = () => {
             }}
             disabled={boolean('disabled', false, 'TimePicker')}
             controls={boolean('controls', isSberbox, 'TimePicker')}
-            autofocus={boolean('autofocus', true, 'TimePicker')}
+            autofocus={boolean('autofocus', false, 'TimePicker')}
             onChange={(val) => {
                 setValue(val);
                 action('onChange')(val);

--- a/packages/plasma-ui/src/components/Pickers/TimePicker.tsx
+++ b/packages/plasma-ui/src/components/Pickers/TimePicker.tsx
@@ -194,7 +194,7 @@ export const TimePicker: React.FC<TimePickerProps> = ({
 
         // eslint-disable-next-line no-restricted-globals
         if (isNaN(newHours) || isNaN(newMins) || isNaN(newSecs)) {
-            return null;
+            throw new Error(`Passed value ${value} is out of range`);
         }
         if (newHours !== hours || newMins !== minutes || newSecs !== seconds) {
             setState([newHours, newMins, newSecs]);


### PR DESCRIPTION
Исправил отсутсвие примера TimePicker'а во вкладке docs. Добавил выброс исключения при значении вне диапазона для TimePicker'а.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/showcase@0.30.0-canary.516.c45779990b30835669be130c6f1b0c90e476588b.0
  npm install @sberdevices/plasma-ui@1.26.0-canary.516.c45779990b30835669be130c6f1b0c90e476588b.0
  npm install @sberdevices/plasma-web@1.24.0-canary.516.c45779990b30835669be130c6f1b0c90e476588b.0
  npm install @sberdevices/plasma-tokens-android@2.14.0-canary.516.c45779990b30835669be130c6f1b0c90e476588b.0
  npm install @sberdevices/plasma-tokens-ios-swift@2.14.0-canary.516.c45779990b30835669be130c6f1b0c90e476588b.0
  # or 
  yarn add @sberdevices/showcase@0.30.0-canary.516.c45779990b30835669be130c6f1b0c90e476588b.0
  yarn add @sberdevices/plasma-ui@1.26.0-canary.516.c45779990b30835669be130c6f1b0c90e476588b.0
  yarn add @sberdevices/plasma-web@1.24.0-canary.516.c45779990b30835669be130c6f1b0c90e476588b.0
  yarn add @sberdevices/plasma-tokens-android@2.14.0-canary.516.c45779990b30835669be130c6f1b0c90e476588b.0
  yarn add @sberdevices/plasma-tokens-ios-swift@2.14.0-canary.516.c45779990b30835669be130c6f1b0c90e476588b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
