### PR TITLE
fix: Pickers performance, no unnecessary rerender

### DIFF
--- a/examples/demo-canvas-app/next.config.js
+++ b/examples/demo-canvas-app/next.config.js
@@ -1,6 +1,8 @@
 const path = require('path');
 const { PUBLIC_URL, PR_NAME } = process.env;
-const basePath = PUBLIC_URL ? PUBLIC_URL + (PR_NAME ? '-' : '') + PR_NAME : '';
+
+const pathSuffix = PR_NAME ? `-${PR_NAME}` : '';
+const basePath = PUBLIC_URL ? `${PUBLIC_URL}${pathSuffix}` : '';
 
 module.exports = {
     basePath,

--- a/examples/demo-canvas-app/pages/test/components/pickers.tsx
+++ b/examples/demo-canvas-app/pages/test/components/pickers.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import styled from 'styled-components';
 import { DatePicker, TimePicker, Footnote2 } from '@sberdevices/plasma-ui';
+import { isSberBox } from '@sberdevices/plasma-ui/utils';
 
 const StyledWrapper = styled.div`
     display: flex;
@@ -24,11 +25,14 @@ const StyledTimePicker = styled(TimePicker)`
     margin-left: 2rem;
 `;
 
+const isSberbox = isSberBox();
+
 export default function PickersPage() {
     const [date, setDate] = useState(new Date());
     const [time, setTime] = useState(new Date());
     const min = new Date(2000, 0, 1, 0, 0, 0);
     const max = new Date(2030, 11, 31, 23, 59, 59);
+    const scrollSnapType = isSberbox ? 'none' : 'mandatory';
 
     return (
         <StyledWrapper>
@@ -40,6 +44,7 @@ export default function PickersPage() {
                     max={max}
                     controls={true}
                     autofocus={true}
+                    scrollSnapType={scrollSnapType}
                     onChange={(d) => setDate(d)}
                 />
                 <StyledTimePicker
@@ -49,6 +54,7 @@ export default function PickersPage() {
                     max={max}
                     controls={true}
                     autofocus={false}
+                    scrollSnapType={scrollSnapType}
                     onChange={(t) => setTime(t)}
                 />
             </StyledPickers>

--- a/packages/plasma-core/src/components/Carousel/Carousel.tsx
+++ b/packages/plasma-core/src/components/Carousel/Carousel.tsx
@@ -113,6 +113,7 @@ export const Carousel = styled.div<Pick<CarouselProps, 'axis' | 'scrollSnapType'
 
     ${({ scrollSnapType, axis }) =>
         scrollSnapType &&
+        scrollSnapType !== 'none' &&
         css`
             scroll-behavior: smooth;
             scroll-snap-type: ${axis} ${scrollSnapType};

--- a/packages/plasma-core/src/types/ScrollSnap.ts
+++ b/packages/plasma-core/src/types/ScrollSnap.ts
@@ -1,2 +1,2 @@
-export type SnapType = 'mandatory' | 'proximity';
+export type SnapType = 'mandatory' | 'proximity' | 'none';
 export type SnapAlign = 'start' | 'center' | 'end';

--- a/packages/plasma-ui/src/components/Pickers/Picker.tsx
+++ b/packages/plasma-ui/src/components/Pickers/Picker.tsx
@@ -6,7 +6,7 @@ import { applyDisabled, DisabledProps } from '@sberdevices/plasma-core';
 
 import { useRemoteListener } from '../../hooks';
 import { Button } from '../Button';
-import { Carousel } from '../Carousel';
+import { Carousel, CarouselProps } from '../Carousel';
 
 import {
     PickerItem,
@@ -130,7 +130,11 @@ const getIndex = (index: number, cmd: '+' | '-', min: number, max: number) => {
     return index !== min ? index - 1 : max;
 };
 
-export interface PickerProps extends SizeProps, DisabledProps, Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> {
+export interface PickerProps
+    extends SizeProps,
+        DisabledProps,
+        Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'>,
+        Pick<CarouselProps, 'scrollSnapType'> {
     /**
      * Список опций
      */
@@ -171,25 +175,18 @@ export const Picker: React.FC<PickerProps> = ({
     disabled,
     visibleItems = 5,
     tabIndex = 0,
+    scrollSnapType,
     onChange,
     ...rest
 }) => {
     const min = 0;
     const max = items.length - 1;
-    const index = items.findIndex((item) => item.value === value);
+    const [index, setIndex] = React.useState(items.findIndex((item) => item.value === value));
     const noScrollBehavior = React.useRef(true);
     const wrapperRef = React.useRef<HTMLDivElement | null>(null);
     const carouselRef = React.useRef<HTMLDivElement | null>(null);
-    const toPrev = React.useCallback(() => !disabled && onChange?.(items[getIndex(index, '-', min, max)]), [
-        index,
-        min,
-        max,
-    ]);
-    const toNext = React.useCallback(() => !disabled && onChange?.(items[getIndex(index, '+', min, max)]), [
-        index,
-        min,
-        max,
-    ]);
+    const toPrev = React.useCallback(() => !disabled && setIndex(getIndex(index, '-', min, max)), [index, min, max]);
+    const toNext = React.useCallback(() => !disabled && setIndex(getIndex(index, '+', min, max)), [index, min, max]);
 
     // Навигация с помощью пульта/клавиатуры
     // Не перелистывает, если компонент неактивен
@@ -243,7 +240,7 @@ export const Picker: React.FC<PickerProps> = ({
                 index={index}
                 scaleCallback={size === 's' ? scaleCallbackS : scaleCallbackL}
                 scaleResetCallback={scaleResetCallback}
-                scrollSnapType="mandatory"
+                scrollSnapType={scrollSnapType}
                 detectActive
                 detectThreshold={0.5}
                 paddingStart={sizes[size][visibleItems].padding}

--- a/packages/plasma-ui/src/components/Pickers/Pickers.stories.mdx
+++ b/packages/plasma-ui/src/components/Pickers/Pickers.stories.mdx
@@ -8,6 +8,10 @@ import { DatePicker, TimePicker } from '.';
 
 <Meta title="Controls/Pickers" decorators={[InSpacing]} />
 
+<Canvas>
+    <Story name="Default" story={stories.Default} />
+</Canvas>
+
 # Pickers
 Набор компонентов для выбора даты и времени.
 
@@ -15,7 +19,7 @@ import { DatePicker, TimePicker } from '.';
 <Description of={DatePicker} />
 
 <Canvas>
-    <Story name="DatePicker" story={stories.DatePicker} />
+    <Story name="DatePicker" story={stories.Date_Picker} />
 </Canvas>
 
 <Props of={DatePicker} />
@@ -24,7 +28,7 @@ import { DatePicker, TimePicker } from '.';
 <Description of={TimePicker} />
 
 <Canvas>
-    <Story name="TimePicker" story={stories.TimePicker} />
+    <Story name="TimePicker" story={stories.Time_Picker} />
 </Canvas>
 
 <Props of={TimePicker} />

--- a/packages/plasma-ui/src/components/Pickers/Pickers.stories.tsx
+++ b/packages/plasma-ui/src/components/Pickers/Pickers.stories.tsx
@@ -1,89 +1,168 @@
 import React from 'react';
+import styled from 'styled-components';
 import { boolean, number, select, text } from '@storybook/addon-knobs';
-import { action } from '@storybook/addon-actions';
+import type { SnapType } from '@sberdevices/plasma-core';
 
 import { isSberBox } from '../../utils';
 
-import { DatePicker as DatePickerComponent, TimePicker as TimePickerComponent } from '.';
+import { DatePicker, TimePicker } from '.';
 
-const now = new Date();
-const dateFromHumanized = (date: string) => {
-    const parsed = date.split('.').map(Number);
-    return new Date(parsed[2], parsed[1] - 1, parsed[0]);
+const StyledWrapper = styled.div`
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(2, max-content);
+    align-items: center;
+`;
+
+const isSberbox = isSberBox();
+const snapTypes = ['mandatory', 'proximity'] as SnapType[];
+
+const parseDateTime = (dateTime: string) => {
+    const [date, time] = dateTime.split(' ');
+    const dated = date.split('.').map(Number);
+    const timed = time.split(':').map(Number);
+
+    return new Date(dated[2], dated[1] - 1, dated[0], timed[0], timed[1], timed[2]);
 };
 
-export const DatePicker = () => {
-    const [value, setValue] = React.useState(dateFromHumanized(text('value', '01.09.1980')));
-    const isSberbox = isSberBox();
+export const Default = () => {
+    const [value, setValue] = React.useState(parseDateTime(text('value', '01.09.1980 00:28:59')));
+    const onChange = React.useCallback((v) => setValue(v), []);
+    const min = parseDateTime(text('min', '01.01.1975 00:15:29'));
+    const max = parseDateTime(text('max', '31.12.1985 12:45:50'));
+    const years = boolean('options.years', true);
+    const months = boolean('options.months', true);
+    const days = boolean('options.days', true);
+    const shortMonthName = boolean('options.shortMonthName', false);
+    const hours = boolean('options.hours', true);
+    const minutes = boolean('options.minutes', true);
+    const seconds = boolean('options.seconds', true);
+    const dateOptions = React.useMemo(
+        () => ({
+            years,
+            months,
+            days,
+            shortMonthName,
+        }),
+        [years, months, days],
+    );
+    const timeOptions = React.useMemo(
+        () => ({
+            hours,
+            minutes,
+            seconds,
+        }),
+        [hours, minutes, seconds],
+    );
+    const disabled = boolean('disabled', false);
+    const controls = boolean('controls', isSberbox);
+    const autofocus = boolean('autofocus', true);
+    const scrollSnapType = select('scrollSnapType', snapTypes, isSberbox ? 'none' : 'mandatory');
 
     return (
-        <DatePickerComponent
+        <StyledWrapper>
+            <DatePicker
+                id="datepicker"
+                value={value}
+                min={min}
+                max={max}
+                size={select('DatePicker size', ['l', 's'], 's')}
+                visibleItems={select('DatePicker visibleItems', [3, 5], 3)}
+                scrollSnapType={scrollSnapType}
+                options={dateOptions}
+                disabled={disabled}
+                controls={controls}
+                autofocus={autofocus}
+                onChange={onChange}
+            />
+            <TimePicker
+                id="timepicker"
+                value={value}
+                min={min}
+                max={max}
+                step={number('TimePicker step', 1)}
+                size={select('TimePicker size', ['l', 's'], 's')}
+                visibleItems={select('TimePicker visibleItems', [3, 5], 5)}
+                scrollSnapType={scrollSnapType}
+                options={timeOptions}
+                disabled={disabled}
+                controls={controls}
+                onChange={onChange}
+            />
+        </StyledWrapper>
+    );
+};
+
+// eslint-disable-next-line @typescript-eslint/camelcase
+export const Date_Picker = () => {
+    const [value, setValue] = React.useState(parseDateTime(text('value', '01.09.1980 00:28:59')));
+    const onChange = React.useCallback((v) => setValue(v), []);
+    const min = parseDateTime(text('min', '01.01.1975 00:15:29'));
+    const max = parseDateTime(text('max', '31.12.1985 12:45:50'));
+    const years = boolean('options.years', true);
+    const months = boolean('options.months', true);
+    const days = boolean('options.days', true);
+    const shortMonthName = boolean('options.shortMonthName', false);
+    const options = React.useMemo(
+        () => ({
+            years,
+            months,
+            days,
+            shortMonthName,
+        }),
+        [years, months, days],
+    );
+
+    return (
+        <DatePicker
+            id="example"
             value={value}
-            min={dateFromHumanized(text('min', '01.01.1975'))}
-            max={dateFromHumanized(text('max', '31.12.1985'))}
+            min={min}
+            max={max}
             size={select('size', ['l', 's'], 's')}
             visibleItems={select('visibleItems', [3, 5], 5)}
-            options={{
-                years: boolean('options.years', true),
-                months: boolean('options.months', true),
-                days: boolean('options.days', true),
-                shortMonthName: boolean('options.shortMonthName', false),
-            }}
+            scrollSnapType={select('scrollSnapType', snapTypes, isSberbox ? 'none' : 'mandatory')}
+            options={options}
             disabled={boolean('disabled', false)}
             controls={boolean('controls', isSberbox)}
             autofocus={boolean('autofocus', true)}
-            onChange={(newValue) => {
-                setValue(newValue);
-            }}
+            onChange={onChange}
         />
     );
 };
 
-export const TimePicker = () => {
-    const [value, setValue] = React.useState(
-        new Date(
-            now.getFullYear(),
-            now.getMonth(),
-            now.getDate(),
-            ...text('value', '0:28:59', 'TimePicker').split(':').map(Number),
-        ),
+// eslint-disable-next-line @typescript-eslint/camelcase
+export const Time_Picker = () => {
+    const [value, setValue] = React.useState(parseDateTime(text('value', '01.09.1980 00:28:59')));
+    const onChange = React.useCallback((v) => setValue(v), []);
+    const min = parseDateTime(text('min', '01.01.1975 00:15:29'));
+    const max = parseDateTime(text('max', '31.12.1985 12:45:50'));
+    const hours = boolean('options.hours', true);
+    const minutes = boolean('options.minutes', true);
+    const seconds = boolean('options.seconds', true);
+    const options = React.useMemo(
+        () => ({
+            hours,
+            minutes,
+            seconds,
+        }),
+        [hours, minutes, seconds],
     );
-    const isSberbox = isSberBox();
 
     return (
-        <TimePickerComponent
+        <TimePicker
             value={value}
-            min={
-                new Date(
-                    now.getFullYear(),
-                    now.getMonth(),
-                    now.getDate(),
-                    ...text('min', '0:15:29', 'TimePicker').split(':').map(Number),
-                )
-            }
-            max={
-                new Date(
-                    now.getFullYear(),
-                    now.getMonth(),
-                    now.getDate(),
-                    ...text('max', '12:45:50', 'TimePicker').split(':').map(Number),
-                )
-            }
-            step={number('step', 1, undefined, 'TimePicker')}
-            size={select('size', ['l', 's'], 'l', 'TimePicker')}
-            visibleItems={select('visibleItems', [3, 5], 3, 'TimePicker')}
-            options={{
-                hours: boolean('options.hours', true, 'TimePicker'),
-                minutes: boolean('options.minutes', true, 'TimePicker'),
-                seconds: boolean('options.seconds', true, 'TimePicker'),
-            }}
-            disabled={boolean('disabled', false, 'TimePicker')}
-            controls={boolean('controls', isSberbox, 'TimePicker')}
-            autofocus={boolean('autofocus', false, 'TimePicker')}
-            onChange={(val) => {
-                setValue(val);
-                action('onChange')(val);
-            }}
+            min={min}
+            max={max}
+            step={number('step', 1)}
+            size={select('size', ['l', 's'], 'l')}
+            visibleItems={select('visibleItems', [3, 5], 3)}
+            scrollSnapType={select('scrollSnapType', snapTypes, isSberbox ? 'none' : 'mandatory')}
+            options={options}
+            disabled={boolean('disabled', false)}
+            controls={boolean('controls', isSberbox)}
+            autofocus={boolean('autofocus', true)}
+            onChange={onChange}
         />
     );
 };

--- a/packages/plasma-ui/src/components/Pickers/SimpleDatePicker.tsx
+++ b/packages/plasma-ui/src/components/Pickers/SimpleDatePicker.tsx
@@ -29,14 +29,16 @@ export interface SimpleDatePickerProps extends Omit<PickerProps, 'items'> {
     monthNameFormat?: MonthNameFormat;
 }
 
-export const SimpleDatePicker: React.FC<SimpleDatePickerProps> = ({ id, type, from, to, monthNameFormat, ...rest }) => {
-    const formatterKey = getFormatterKey(type, monthNameFormat);
-    const formatter = labelFormatter[formatterKey];
+export const SimpleDatePicker = React.memo<SimpleDatePickerProps>(
+    ({ id, type, from, to, monthNameFormat, ...rest }) => {
+        const formatterKey = getFormatterKey(type, monthNameFormat);
+        const formatter = labelFormatter[formatterKey];
 
-    const items = Array.from({ length: to - from + 1 }, (_, i) => ({
-        label: formatter(from + i),
-        value: from + i,
-    }));
+        const items = Array.from({ length: to - from + 1 }, (_, i) => ({
+            label: formatter(from + i),
+            value: from + i,
+        }));
 
-    return <Picker id={id ? `${id}-${type}` : undefined} items={items} {...rest} />;
-};
+        return <Picker id={id ? `${id}-${type}` : undefined} items={items} {...rest} />;
+    },
+);

--- a/packages/plasma-ui/src/components/Pickers/SimpleTimePicker.tsx
+++ b/packages/plasma-ui/src/components/Pickers/SimpleTimePicker.tsx
@@ -8,15 +8,11 @@ export interface SimpleTimePickerProps extends Omit<PickerProps, 'items'> {
     range: number[];
 }
 
-export const SimpleTimePicker: React.FC<SimpleTimePickerProps> = ({ id, type, range, ...rest }) => {
-    const items = React.useMemo(
-        () =>
-            range.map((value) => ({
-                label: formatter(value),
-                value,
-            })),
-        [range],
-    );
+export const SimpleTimePicker = React.memo<SimpleTimePickerProps>(({ id, type, range, ...rest }) => {
+    const items = range.map((value) => ({
+        label: formatter(value),
+        value,
+    }));
 
     return <Picker id={id ? `${id}-${type}` : undefined} items={items} {...rest} />;
-};
+});

--- a/packages/plasma-ui/src/components/Pickers/TimePicker.tsx
+++ b/packages/plasma-ui/src/components/Pickers/TimePicker.tsx
@@ -117,36 +117,37 @@ export const TimePicker: React.FC<TimePickerProps> = ({
     disabled,
     controls,
     autofocus,
+    scrollSnapType,
     onChange,
     ...rest
 }) => {
     const [[hours, minutes, seconds], setState] = React.useState(getValues(value));
+    const [minHours, minMinutes, minSeconds] = getValues(min);
+    const [maxHours, maxMinutes, maxSeconds] = getValues(max);
 
     // Диапозоны для списков зависят от min и max,
     // при чем min и max принимаются как возможные предельные значения,
     // а не как контейнеры для компонент hours, minutes, seconds
     const [hoursRange, minsRange, secsRange] = React.useMemo(() => {
-        const minHours = min.getHours();
-        const maxHours = max.getHours();
         let minMins = 0;
         let maxMins = 59;
         let minSecs = 0;
         let maxSecs = 59;
 
         if (hours === minHours) {
-            minMins = min.getMinutes();
+            minMins = minMinutes;
         }
 
-        if (minutes === min.getMinutes()) {
-            minSecs = min.getSeconds();
+        if (minutes === minMinutes) {
+            minSecs = minSeconds;
         }
 
         if (hours === maxHours) {
-            maxMins = max.getMinutes();
+            maxMins = maxMinutes;
         }
 
-        if (minutes === max.getMinutes()) {
-            maxSecs = max.getSeconds();
+        if (minutes === maxMinutes) {
+            maxSecs = maxSeconds;
         }
 
         let hoursStep = 1;
@@ -166,7 +167,7 @@ export const TimePicker: React.FC<TimePickerProps> = ({
             getRange(minMins, maxMins, minsStep),
             getRange(minSecs, maxSecs, secsStep),
         ];
-    }, [min, max, hours, minutes, step]);
+    }, [minHours, maxHours, minMinutes, maxMinutes, minSeconds, maxSeconds, hours, minutes, step]);
 
     const onHoursChange = React.useCallback(({ value: h }) => setState(([, m, s]) => [h, m, s]), []);
     const onMinutesChange = React.useCallback(({ value: m }) => setState(([h, , s]) => [h, m, s]), []);
@@ -215,6 +216,7 @@ export const TimePicker: React.FC<TimePickerProps> = ({
                     size={size}
                     range={hoursRange}
                     value={hours}
+                    scrollSnapType={scrollSnapType}
                     onChange={onHoursChange}
                 />
             )}
@@ -229,6 +231,7 @@ export const TimePicker: React.FC<TimePickerProps> = ({
                     size={size}
                     range={minsRange}
                     value={minutes}
+                    scrollSnapType={scrollSnapType}
                     onChange={onMinutesChange}
                 />
             )}
@@ -243,6 +246,7 @@ export const TimePicker: React.FC<TimePickerProps> = ({
                     size={size}
                     range={secsRange}
                     value={seconds}
+                    scrollSnapType={scrollSnapType}
                     onChange={onSecondsChange}
                 />
             )}


### PR DESCRIPTION
Closes #469 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/showcase@0.31.1-canary.527.5c60d9407455719b8f901610ef8f23db832fc4f6.0
  npm install @sberdevices/demo-canvas-app@0.3.1-canary.527.5c60d9407455719b8f901610ef8f23db832fc4f6.0
  npm install @sberdevices/plasma-core@1.18.1-canary.527.5c60d9407455719b8f901610ef8f23db832fc4f6.0
  npm install @sberdevices/plasma-icons@1.23.1-canary.527.5c60d9407455719b8f901610ef8f23db832fc4f6.0
  npm install @sberdevices/plasma-ui@1.27.1-canary.527.5c60d9407455719b8f901610ef8f23db832fc4f6.0
  npm install @sberdevices/plasma-web@1.25.1-canary.527.5c60d9407455719b8f901610ef8f23db832fc4f6.0
  npm install @sberdevices/plasma-sb-utils@0.8.1-canary.527.5c60d9407455719b8f901610ef8f23db832fc4f6.0
  # or 
  yarn add @sberdevices/showcase@0.31.1-canary.527.5c60d9407455719b8f901610ef8f23db832fc4f6.0
  yarn add @sberdevices/demo-canvas-app@0.3.1-canary.527.5c60d9407455719b8f901610ef8f23db832fc4f6.0
  yarn add @sberdevices/plasma-core@1.18.1-canary.527.5c60d9407455719b8f901610ef8f23db832fc4f6.0
  yarn add @sberdevices/plasma-icons@1.23.1-canary.527.5c60d9407455719b8f901610ef8f23db832fc4f6.0
  yarn add @sberdevices/plasma-ui@1.27.1-canary.527.5c60d9407455719b8f901610ef8f23db832fc4f6.0
  yarn add @sberdevices/plasma-web@1.25.1-canary.527.5c60d9407455719b8f901610ef8f23db832fc4f6.0
  yarn add @sberdevices/plasma-sb-utils@0.8.1-canary.527.5c60d9407455719b8f901610ef8f23db832fc4f6.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
