### PR TITLE
fix(plasma-ui): Toast fade top placement

### DIFF
--- a/examples/demo-canvas-app/pages/_app.tsx
+++ b/examples/demo-canvas-app/pages/_app.tsx
@@ -1,6 +1,6 @@
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
-import { DeviceThemeProvider, Container } from '@sberdevices/plasma-ui';
+import { DeviceThemeProvider, ToastProvider, Container } from '@sberdevices/plasma-ui';
 
 import { GlobalStyle } from '../components';
 
@@ -11,10 +11,12 @@ function MyApp({ Component, pageProps }: AppProps) {
                 <title>Demo Canvas App</title>
             </Head>
             <DeviceThemeProvider>
-                <Container>
-                    <Component {...pageProps} />
-                    <GlobalStyle />
-                </Container>
+                <ToastProvider>
+                    <Container>
+                        <Component {...pageProps} />
+                        <GlobalStyle />
+                    </Container>
+                </ToastProvider>
             </DeviceThemeProvider>
         </>
     );

--- a/examples/demo-canvas-app/pages/index.tsx
+++ b/examples/demo-canvas-app/pages/index.tsx
@@ -6,6 +6,7 @@ const menu = [
     { href: '/test/components/pickers/', title: 'Pickers' },
     { href: '/test/components/switch/', title: 'Switch' },
     { href: '/test/components/text-field/', title: 'TextField' },
+    { href: '/test/components/toast/', title: 'Toast' },
 ];
 
 const StyledCard = styled.a`

--- a/examples/demo-canvas-app/pages/test/components/toast.tsx
+++ b/examples/demo-canvas-app/pages/test/components/toast.tsx
@@ -1,0 +1,36 @@
+import { Button, useToast } from '@sberdevices/plasma-ui';
+import styled from 'styled-components';
+
+const StyledWrapper = styled.div`
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+
+    width: 100%;
+    height: 100%;
+    padding: 1rem;
+`;
+const StyledGrid = styled.div`
+    box-sizing: border-box;
+    display: grid;
+    grid-template-columns: repeat(2, calc(50% - 0.5rem));
+    gap: 1rem;
+    width: 100%;
+`;
+
+const text = 'Toast message!';
+const timeout = 3000;
+const fade = true;
+
+export default function ToastPage() {
+    const { showToast } = useToast();
+    console.log(showToast);
+    return (
+        <StyledWrapper>
+            <StyledGrid>
+                <Button onClick={() => showToast(text, 'top', timeout, fade)}>Show top</Button>
+                <Button onClick={() => showToast(text, 'bottom', timeout, fade)}>Show bottom</Button>
+            </StyledGrid>
+        </StyledWrapper>
+    );
+}

--- a/packages/plasma-ui/src/components/Fade/Fade.tsx
+++ b/packages/plasma-ui/src/components/Fade/Fade.tsx
@@ -1,11 +1,16 @@
 import styled from 'styled-components';
 
-export const Fade = styled.div`
+const gradients = {
+    top: 'radial-gradient(200% 200% at 50% -100%, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0) 100%)',
+    bottom: 'radial-gradient(200% 200% at 50% 200%, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0) 100%)',
+};
+
+export const Fade = styled.div<{ placement?: 'top' | 'bottom' }>`
     position: fixed;
     top: 0;
     left: 0;
     right: 0;
     bottom: 0;
     z-index: 999;
-    background: radial-gradient(200% 200% at 50% 200%, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0) 100%);
+    background: ${({ placement = 'bottom' }) => gradients[placement]};
 `;

--- a/packages/plasma-ui/src/components/Toast/Toast.stories.mdx
+++ b/packages/plasma-ui/src/components/Toast/Toast.stories.mdx
@@ -73,5 +73,5 @@ type Position = 'top' | 'bottom';
 
 ### Вызов с помощью контекста/хука
 <Canvas>
-    <Story name="ToastContext" story={stories.ToastContext} />
+    <Story name="LiveDemo" story={stories.LiveDemo} />
 </Canvas>

--- a/packages/plasma-ui/src/components/Toast/Toast.stories.tsx
+++ b/packages/plasma-ui/src/components/Toast/Toast.stories.tsx
@@ -9,7 +9,7 @@ export const ToastComponent = () => {
     return <Toast text={text('text', 'Short Text Message Without Action')} />;
 };
 
-export const ToastContext = () => {
+export const LiveDemo = () => {
     const { showToast } = useToast();
 
     const toastText = text('text', 'Short Text Message Without Action');
@@ -38,7 +38,7 @@ export const ToastContext = () => {
     );
 };
 
-ToastContext.parameters = {
+LiveDemo.parameters = {
     chromatic: {
         disable: true,
     },

--- a/packages/plasma-ui/src/components/Toast/ToastController.tsx
+++ b/packages/plasma-ui/src/components/Toast/ToastController.tsx
@@ -112,7 +112,7 @@ export const ToastController: React.FC<ToastInfo> = ({ text, position, timeout, 
 
     return (
         <>
-            {fade && <StyledFade isVisible={isVisible} />}
+            {fade && <StyledFade isVisible={isVisible} placement={position} />}
             <StyledRoot key={toastKey} position={position} isVisible={isVisible} onAnimationEnd={animationEndHandler}>
                 <Toast text={text} />
             </StyledRoot>


### PR DESCRIPTION
Closes #495 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/showcase@0.31.2-canary.528.90276fe6b24b303451dc601816d90e730b065d2b.0
  npm install @sberdevices/demo-canvas-app@0.3.2-canary.528.90276fe6b24b303451dc601816d90e730b065d2b.0
  npm install @sberdevices/plasma-icons@1.23.2-canary.528.90276fe6b24b303451dc601816d90e730b065d2b.0
  npm install @sberdevices/plasma-ui@1.27.2-canary.528.90276fe6b24b303451dc601816d90e730b065d2b.0
  npm install @sberdevices/plasma-web@1.25.2-canary.528.90276fe6b24b303451dc601816d90e730b065d2b.0
  npm install @sberdevices/plasma-sb-utils@0.8.2-canary.528.90276fe6b24b303451dc601816d90e730b065d2b.0
  # or 
  yarn add @sberdevices/showcase@0.31.2-canary.528.90276fe6b24b303451dc601816d90e730b065d2b.0
  yarn add @sberdevices/demo-canvas-app@0.3.2-canary.528.90276fe6b24b303451dc601816d90e730b065d2b.0
  yarn add @sberdevices/plasma-icons@1.23.2-canary.528.90276fe6b24b303451dc601816d90e730b065d2b.0
  yarn add @sberdevices/plasma-ui@1.27.2-canary.528.90276fe6b24b303451dc601816d90e730b065d2b.0
  yarn add @sberdevices/plasma-web@1.25.2-canary.528.90276fe6b24b303451dc601816d90e730b065d2b.0
  yarn add @sberdevices/plasma-sb-utils@0.8.2-canary.528.90276fe6b24b303451dc601816d90e730b065d2b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
