### PR TITLE
fix(plasma-web): TextField can accept deferred defaultValue

### DIFF
--- a/packages/plasma-web/src/components/TextArea/TextArea.tsx
+++ b/packages/plasma-web/src/components/TextArea/TextArea.tsx
@@ -21,7 +21,6 @@ export interface TextAreaProps extends BaseProps {
 export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
     (
         {
-            value,
             placeholder,
             label,
             helperText,
@@ -53,7 +52,6 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
                     as={TextFieldTextarea}
                     ref={ref}
                     id={id}
-                    value={value}
                     placeholder={label || placeholder}
                     disabled={disabled}
                     status={status}

--- a/packages/plasma-web/src/components/TextField/TextField.stories.tsx
+++ b/packages/plasma-web/src/components/TextField/TextField.stories.tsx
@@ -41,6 +41,20 @@ export const Default = () => {
     );
 };
 
-export const DefaultValue = () => {
-    return <TextField size="l" placeholder="Type here" defaultValue="" onInput={onInput} />;
+export const DeferredValue = () => {
+    const [asyncValue, setAsyncValue] = React.useState('');
+
+    React.useEffect(() => {
+        setTimeout(() => {
+            setAsyncValue("Sorry i'm late :)");
+        }, 3000);
+    }, []);
+
+    return (
+        <TextField
+            placeholder="Wait three seconds..."
+            defaultValue={asyncValue}
+            readOnly={boolean('readOnly', true, 'DeferredValue')}
+        />
+    );
 };

--- a/packages/plasma-web/src/components/TextField/TextField.tsx
+++ b/packages/plasma-web/src/components/TextField/TextField.tsx
@@ -17,8 +17,6 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
     (
         {
             size = 'm',
-            value,
-            defaultValue,
             placeholder,
             label,
             helperText,
@@ -56,8 +54,6 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
                     ref={ref}
                     id={id}
                     as={TextFieldInput}
-                    value={value}
-                    defaultValue={defaultValue}
                     placeholder={placeLabel}
                     disabled={disabled}
                     status={status}


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/showcase@0.31.3-canary.536.5e19a14db10061816f4d988131df10f89b67a2ca.0
  npm install @sberdevices/demo-canvas-app@0.3.3-canary.536.5e19a14db10061816f4d988131df10f89b67a2ca.0
  npm install @sberdevices/plasma-ui@1.27.3-canary.536.5e19a14db10061816f4d988131df10f89b67a2ca.0
  npm install @sberdevices/plasma-web@1.25.3-canary.536.5e19a14db10061816f4d988131df10f89b67a2ca.0
  # or 
  yarn add @sberdevices/showcase@0.31.3-canary.536.5e19a14db10061816f4d988131df10f89b67a2ca.0
  yarn add @sberdevices/demo-canvas-app@0.3.3-canary.536.5e19a14db10061816f4d988131df10f89b67a2ca.0
  yarn add @sberdevices/plasma-ui@1.27.3-canary.536.5e19a14db10061816f4d988131df10f89b67a2ca.0
  yarn add @sberdevices/plasma-web@1.25.3-canary.536.5e19a14db10061816f4d988131df10f89b67a2ca.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
