### PR TITLE
fix(plasma-icons): chevron-icons updated

### DIFF
--- a/packages/plasma-icons/src/Icon.assets/ChevronDown.tsx
+++ b/packages/plasma-icons/src/Icon.assets/ChevronDown.tsx
@@ -3,11 +3,11 @@ import React from 'react';
 import { IconProps } from '../IconRoot';
 
 export const ChevronDown: React.FC<IconProps> = (props) => (
-    <svg width="100%" viewBox="0 0 16 16" fill="none" {...props}>
+    <svg width="100%" viewBox="0 0 24 24" fill="none" {...props}>
         <path
             fillRule="evenodd"
             clipRule="evenodd"
-            d="M3.293 5.293a1 1 0 011.414 0l2.586 2.586a1 1 0 001.414 0l2.586-2.586a1 1 0 111.414 1.414l-2.586 2.586a3 3 0 01-4.242 0L3.293 6.707a1 1 0 010-1.414z"
+            d="M3.356 7.349a1.235 1.235 0 011.72 0L12 14.126l6.924-6.777a1.235 1.235 0 011.72 0 1.173 1.173 0 010 1.683l-7.784 7.62A1.23 1.23 0 0112 17a1.23 1.23 0 01-.86-.349L3.356 9.032a1.173 1.173 0 010-1.683z"
             fill="currentColor"
         />
     </svg>

--- a/packages/plasma-icons/src/Icon.assets/ChevronUp.tsx
+++ b/packages/plasma-icons/src/Icon.assets/ChevronUp.tsx
@@ -3,11 +3,11 @@ import React from 'react';
 import { IconProps } from '../IconRoot';
 
 export const ChevronUp: React.FC<IconProps> = (props) => (
-    <svg width="100%" viewBox="0 0 16 16" fill="none" {...props}>
+    <svg width="100%" viewBox="0 0 24 24" fill="none" {...props}>
         <path
             fillRule="evenodd"
             clipRule="evenodd"
-            d="M3.293 10.707a1 1 0 001.414 0l2.586-2.586a1 1 0 011.414 0l2.586 2.586a1 1 0 001.414-1.414l-2.586-2.586a3 3 0 00-4.242 0L3.293 9.293a1 1 0 000 1.414z"
+            d="M20.644 16.651a1.235 1.235 0 01-1.72 0L12 9.874l-6.924 6.777a1.235 1.235 0 01-1.72 0 1.173 1.173 0 010-1.683l7.784-7.62A1.23 1.23 0 0112 7c.322 0 .632.125.86.349l7.784 7.619a1.173 1.173 0 010 1.683z"
             fill="currentColor"
         />
     </svg>


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/showcase@0.34.3-canary.555.4772fe375bcd070f0b02bfaa9153d9f08083287b.0
  npm install @sberdevices/demo-canvas-app@0.6.3-canary.555.4772fe375bcd070f0b02bfaa9153d9f08083287b.0
  npm install @sberdevices/plasma-icons@1.25.1-canary.555.4772fe375bcd070f0b02bfaa9153d9f08083287b.0
  npm install @sberdevices/plasma-ui@1.30.3-canary.555.4772fe375bcd070f0b02bfaa9153d9f08083287b.0
  npm install @sberdevices/plasma-web@1.28.3-canary.555.4772fe375bcd070f0b02bfaa9153d9f08083287b.0
  # or 
  yarn add @sberdevices/showcase@0.34.3-canary.555.4772fe375bcd070f0b02bfaa9153d9f08083287b.0
  yarn add @sberdevices/demo-canvas-app@0.6.3-canary.555.4772fe375bcd070f0b02bfaa9153d9f08083287b.0
  yarn add @sberdevices/plasma-icons@1.25.1-canary.555.4772fe375bcd070f0b02bfaa9153d9f08083287b.0
  yarn add @sberdevices/plasma-ui@1.30.3-canary.555.4772fe375bcd070f0b02bfaa9153d9f08083287b.0
  yarn add @sberdevices/plasma-web@1.28.3-canary.555.4772fe375bcd070f0b02bfaa9153d9f08083287b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
