### PR TITLE
fix(plasma-web): form submit trigger inside select

### DIFF
--- a/packages/plasma-web/src/components/Select/SelectView.tsx
+++ b/packages/plasma-web/src/components/Select/SelectView.tsx
@@ -148,7 +148,7 @@ export const SelectView = React.forwardRef<RefElement, SelectViewProps>(
                 style={style}
             >
                 <StyledDropdown offsetTop="0.25rem" items={items} onItemClick={onItemClick}>
-                    <StyledButton ref={ref} disabled={disabled} status={status} {...rest}>
+                    <StyledButton ref={ref} disabled={disabled} status={status} type="button" {...rest}>
                         {value && <StyledText>{value}</StyledText>}
                         {placeholder && !value && <StyledPlaceholder>{placeholder}</StyledPlaceholder>}
                         {isIcon && <StyledArrow size="xs" color="inherit" />}


### PR DESCRIPTION
`<SelectView>` вызывал submit внутри форм, т.к. дефолтное значение type для `<button>` это submit.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/showcase@0.35.1-canary.557.53bae8d60ce9ee8899e0978f9f4d251300c906bd.0
  npm install @sberdevices/plasma-web@1.29.1-canary.557.53bae8d60ce9ee8899e0978f9f4d251300c906bd.0
  # or 
  yarn add @sberdevices/showcase@0.35.1-canary.557.53bae8d60ce9ee8899e0978f9f4d251300c906bd.0
  yarn add @sberdevices/plasma-web@1.29.1-canary.557.53bae8d60ce9ee8899e0978f9f4d251300c906bd.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
