### PR TITLE
fix(plasma-ui): huawei detection fix

### DIFF
--- a/packages/plasma-ui/src/utils/deviceDetection.ts
+++ b/packages/plasma-ui/src/utils/deviceDetection.ts
@@ -59,7 +59,12 @@ export const isTV = (): boolean => {
 
     const ua = navigator.userAgent.toLowerCase();
 
-    return ua.includes('(tv; tv)') || ua.includes('(tv; huawei)') || ua.includes('(huawei-tv; huawei)');
+    return (
+        ua.includes('(tv; tv)') ||
+        ua.includes('(tv; huawei)') ||
+        ua.includes('(huawei-tv; huawei)') ||
+        ua.includes('(huawei-tv; huawei tv)')
+    );
 };
 
 /**


### PR DESCRIPTION
Не поддерживалось определение userAgent для ```Mozilla/5.0 (Linux; Android 10; KANT-359 Build/HUAWEIKANT-359; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 Mobile Safari/537.36 ASDK/21.4.2.0 (Android) StarOS/1.71.16 (huawei-tv; Huawei TV)```
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/showcase@0.36.1-canary.583.eb4eff21145e2b03ac416482dbc825e32d70678a.0
  npm install @sberdevices/demo-canvas-app@0.8.1-canary.583.eb4eff21145e2b03ac416482dbc825e32d70678a.0
  npm install @sberdevices/plasma-ui@1.31.1-canary.583.eb4eff21145e2b03ac416482dbc825e32d70678a.0
  npm install @sberdevices/plasma-web@1.30.1-canary.583.eb4eff21145e2b03ac416482dbc825e32d70678a.0
  # or 
  yarn add @sberdevices/showcase@0.36.1-canary.583.eb4eff21145e2b03ac416482dbc825e32d70678a.0
  yarn add @sberdevices/demo-canvas-app@0.8.1-canary.583.eb4eff21145e2b03ac416482dbc825e32d70678a.0
  yarn add @sberdevices/plasma-ui@1.31.1-canary.583.eb4eff21145e2b03ac416482dbc825e32d70678a.0
  yarn add @sberdevices/plasma-web@1.30.1-canary.583.eb4eff21145e2b03ac416482dbc825e32d70678a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
