### PR TITLE
chore(plasma-ui, plasma-web): knobs to controls migration - part 1

### DIFF
--- a/packages/plasma-ui/src/components/Badge/Badge.stories.tsx
+++ b/packages/plasma-ui/src/components/Badge/Badge.stories.tsx
@@ -1,26 +1,53 @@
 import React from 'react';
-import { text, boolean, select } from '@storybook/addon-knobs';
+import { Story, Meta } from '@storybook/react';
 import { IconSettings } from '@sberdevices/plasma-icons';
 
-import { Badge, badgeSizes, badgeViews, BadgeSize, BadgeView } from '.';
+import { disableProps } from '../../helpers';
 
-const sizeKeys = Object.keys(badgeSizes) as BadgeSize[];
-const viewKeys = Object.keys(badgeViews) as BadgeView[];
+import { Badge, BadgeProps, badgeSizes, badgeViews } from '.';
 
-export const Default = () => (
-    <Badge
-        text={text('text', 'Badge')}
-        size={select('size', sizeKeys, 'l')}
-        view={select('view', viewKeys, 'primary')}
-        contentLeft={boolean('Enable icon', false) && <IconSettings color="inherit" size="xs" />}
-    />
+const propsToDisable = ['contentLeft', 'theme', 'as', 'forwardedAs'];
+
+export default {
+    title: 'Content/Badge',
+    component: Badge,
+    argTypes: {
+        size: {
+            control: {
+                type: 'inline-radio',
+                options: Object.keys(badgeSizes),
+            },
+        },
+        view: {
+            control: {
+                type: 'inline-radio',
+                options: Object.keys(badgeViews),
+            },
+        },
+        ...disableProps(propsToDisable),
+    },
+} as Meta;
+
+export const Default: Story<BadgeProps & { enableIcon: boolean }> = ({ enableIcon, ...rest }) => (
+    <Badge contentLeft={enableIcon && <IconSettings color="inherit" size="xs" />} {...rest} />
 );
 
-export const Quantity = () => (
-    <Badge
-        text={text('quantity', '11')}
-        size={select('size', sizeKeys, 's')}
-        view={select('view', viewKeys, 'secondary')}
-        circled={boolean('circled', true)}
-    />
-);
+Default.args = {
+    text: 'Badge',
+    size: 'l',
+    view: 'primary',
+    enableIcon: false,
+};
+
+Default.argTypes = {
+    circled: { table: { disable: true } },
+};
+
+export const Quantity: Story<BadgeProps> = (args) => <Badge {...args} />;
+
+Quantity.args = {
+    text: '11',
+    size: 's',
+    view: 'secondary',
+    circled: true,
+};

--- a/packages/plasma-ui/src/components/Button/Button.stories.tsx
+++ b/packages/plasma-ui/src/components/Button/Button.stories.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { text, boolean, select } from '@storybook/addon-knobs';
+import { Story, Meta } from '@storybook/react';
 import { IconMic } from '@sberdevices/plasma-icons';
 
-import { actionWithPersistedEvent } from '../../helpers';
+import { actionWithPersistedEvent, disableProps } from '../../helpers';
 
-import { Button, ActionButton } from '.';
+import { Button, ButtonProps, ActionButtonProps, ActionButton } from '.';
 
 const sizes = ['l', 'm', 's'];
 const views = ['primary', 'secondary', 'warning', 'critical', 'checked', 'overlay', 'clear'];
@@ -22,38 +22,96 @@ const onClick = actionWithPersistedEvent('onClick');
 const onFocus = actionWithPersistedEvent('onFocus');
 const onBlur = actionWithPersistedEvent('onBlur');
 
-export const Default = () => (
-    <Button
-        text={text('text', 'Hello Plasma')}
-        size={select('size', sizes, 'm') as 'm'}
-        view={select('view', views, 'primary') as 'primary'}
-        pin={select('pin', pins, 'square-square') as 'square-square'}
-        contentLeft={boolean('contentLeft', true) && <IconMic size="s" color="inherit" />}
-        scaleOnInteraction={boolean('scaleOnInteraction', true)}
-        outlined={boolean('outlined', true)}
-        focused={boolean('focused', false)}
-        disabled={boolean('disabled', false)}
-        square={boolean('square', false)}
-        stretch={boolean('stretch', false)}
-        onClick={onClick}
-        onFocus={onFocus}
-        onBlur={onBlur}
-    />
+const propsToDisable = [
+    'theme',
+    'as',
+    'forwardedAs',
+    'scaleOnHover',
+    'scaleOnPress',
+    'contentLeft',
+    'contentRight',
+    'shiftLeft',
+    'shiftRight',
+    'onClick',
+    'onFocus',
+    'onBlur',
+    'blur',
+];
+
+export default {
+    title: 'Controls/Button',
+    argTypes: {
+        text: {
+            control: {
+                type: 'text',
+            },
+        },
+        size: {
+            control: {
+                type: 'inline-radio',
+                options: sizes,
+            },
+        },
+        view: {
+            control: {
+                type: 'select',
+                options: views,
+            },
+        },
+        pin: {
+            control: {
+                type: 'select',
+                options: pins,
+            },
+        },
+        ...disableProps(propsToDisable),
+    },
+} as Meta;
+
+export const Default: Story<ButtonProps & { enableIcon: boolean }> = ({ enableIcon, ...rest }) => (
+    <Button contentLeft={enableIcon && <IconMic size="s" color="inherit" />} {...rest} />
 );
 
+Default.args = {
+    text: 'Hello Plasma',
+    size: 'm',
+    view: 'primary',
+    pin: 'square-square',
+    enableIcon: true,
+    scaleOnInteraction: true,
+    outlined: true,
+    focused: false,
+    disabled: false,
+    square: false,
+    stretch: false,
+    onClick,
+    onFocus,
+    onBlur,
+};
+
 // eslint-disable-next-line @typescript-eslint/camelcase
-export const Action_Button = () => (
-    <ActionButton
-        size={select('size', sizes, 'm') as 'm'}
-        view={select('view', views, 'primary') as 'primary'}
-        pin={select('pin', [pins[0], pins[pins.length - 1]], 'square-square') as 'square-square'}
-        scaleOnInteraction={boolean('scaleOnInteraction', true)}
-        disabled={boolean('disabled', false)}
-        tabIndex={0}
-        onClick={onClick}
-        onFocus={onFocus}
-        onBlur={onBlur}
-    >
+export const Action_Button: Story<ActionButtonProps> = (args) => (
+    <ActionButton {...args}>
         <IconMic size="xs" color="inherit" />
     </ActionButton>
 );
+
+// eslint-disable-next-line @typescript-eslint/camelcase
+Action_Button.args = {
+    size: 'm',
+    view: 'primary',
+    pin: 'square-square',
+    scaleOnInteraction: true,
+    disabled: false,
+    tabIndex: 0,
+    onClick,
+    onFocus,
+    onBlur,
+};
+
+const ActionButtonPropsToDisable = ['text', 'tabIndex', 'square', 'focused', 'outlined', 'stretch'];
+
+// eslint-disable-next-line @typescript-eslint/camelcase
+Action_Button.argTypes = {
+    ...disableProps(ActionButtonPropsToDisable),
+};

--- a/packages/plasma-ui/src/components/Icon/Icon.stories.tsx
+++ b/packages/plasma-ui/src/components/Icon/Icon.stories.tsx
@@ -1,13 +1,28 @@
 import React from 'react';
-import { text } from '@storybook/addon-knobs';
+import { Story, Meta } from '@storybook/react';
 
-import { IconSet } from './IconSet';
+import { disableProps } from '../../helpers';
+
+import { IconSet, IconSetProps } from './IconSet';
+
+const propsToDisable = ['size', 'exclude', 'include'];
+
+export default {
+    title: 'Content/Icon',
+    component: IconSet,
+    argTypes: {
+        ...disableProps(propsToDisable),
+    },
+} as Meta;
 
 export const XsSize = () => <IconSet size="xs" include={['chevronUp', 'chevronDown', 'disclosureRight']} />;
 
 export const SmallSize = () => <IconSet size="s" exclude={['chevronUp', 'chevronDown']} />;
 
-export const CustomColor = () => {
-    const color = text('color', '#fc0');
-    return <IconSet color={color} exclude={['chevronUp', 'chevronDown']} />;
+export const CustomColor: Story<IconSetProps> = ({ color }) => (
+    <IconSet color={color} exclude={['chevronUp', 'chevronDown']} />
+);
+
+CustomColor.args = {
+    color: '#fc0',
 };

--- a/packages/plasma-ui/src/components/Icon/IconSet.tsx
+++ b/packages/plasma-ui/src/components/Icon/IconSet.tsx
@@ -20,7 +20,7 @@ const StyledHeading = styled(Headline3)`
     color: ${({ color }) => color};
 `;
 
-interface IconSetProps {
+export interface IconSetProps {
     size?: IconSize;
     color?: string;
     exclude?: Array<IName>;

--- a/packages/plasma-ui/src/components/Image/Image.stories.tsx
+++ b/packages/plasma-ui/src/components/Image/Image.stories.tsx
@@ -1,32 +1,51 @@
 import React from 'react';
-import { select } from '@storybook/addon-knobs';
+import { Story, Meta } from '@storybook/react';
 
+import { disableProps } from '../../helpers';
 import { InSpacing } from '../../helpers/StoryDecorators';
 
-import { Image } from '.';
+import { Image, ImageProps, Ratio } from '.';
+
+const bases = ['div', 'img'];
+
+const propsToDisable = ['view', 'height', 'customRatio'];
+
+const ratios = ['1/1', '3/4', '4/3', '9/16', '16/9', '1/2', '2/1'];
 
 export default {
     title: 'Content/Image',
     component: Image,
     decorators: [InSpacing],
-};
+    argTypes: {
+        base: {
+            control: {
+                type: 'inline-radio',
+                options: bases,
+            },
+        },
+        ratio: {
+            control: {
+                type: 'select',
+                options: ratios,
+            },
+        },
+        ...disableProps(propsToDisable),
+    },
+} as Meta;
 
-const bases = ['div', 'img'];
-
-export const Default = () => (
-    <div style={{ maxWidth: '10rem' }}>
-        <Image src="./images/320_320_9.jpg" ratio="1 / 1" alt="картинка для примера" />
-    </div>
-);
-
-export const Basic = () => (
+export const Default: Story<ImageProps & { ratio: Ratio }> = ({ base, ratio }) => (
     <div style={{ maxWidth: '10rem' }}>
         <Image
             src="./images/320_320_9.jpg"
-            ratio="1 / 1"
-            base={select('base', bases, 'div') as 'div'}
+            ratio={ratio}
+            base={base}
             alt="картинка для примера фоном"
             style={{ position: 'relative' }}
         />
     </div>
 );
+
+Default.args = {
+    base: 'div',
+    ratio: '1/1',
+};

--- a/packages/plasma-ui/src/helpers/disableProps.tsx
+++ b/packages/plasma-ui/src/helpers/disableProps.tsx
@@ -1,0 +1,11 @@
+/**
+ * Для сокрытия ненужных пропсов, которые автогенерируются
+ * аддоном Controls
+ */
+export const disableProps = (props: string[]) => {
+    const disabled = {};
+    props.forEach((prop) => {
+        disabled[prop] = { table: { disable: true } };
+    });
+    return disabled;
+};

--- a/packages/plasma-ui/src/helpers/index.ts
+++ b/packages/plasma-ui/src/helpers/index.ts
@@ -1,5 +1,7 @@
 export { actionWithPersistedEvent } from './actionWithPersistedEvent';
 
+export { disableProps } from './disableProps';
+
 export { GridLines } from './GridLines';
 export type { GridLinesProps } from './GridLines';
 


### PR DESCRIPTION
UI:
+ Badge
+ Button
+ Icon
+ Image

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/showcase@0.42.0-canary.627.45dee6832de7942c62c9625b63e4dde665c7bf3c.0
  npm install @sberdevices/demo-canvas-app@0.14.0-canary.627.45dee6832de7942c62c9625b63e4dde665c7bf3c.0
  npm install @sberdevices/plasma-icons@1.32.0-canary.627.45dee6832de7942c62c9625b63e4dde665c7bf3c.0
  npm install @sberdevices/plasma-ui@1.37.0-canary.627.45dee6832de7942c62c9625b63e4dde665c7bf3c.0
  npm install @sberdevices/plasma-web@1.36.0-canary.627.45dee6832de7942c62c9625b63e4dde665c7bf3c.0
  npm install @sberdevices/plasma-sb-utils@0.16.0-canary.627.45dee6832de7942c62c9625b63e4dde665c7bf3c.0
  # or 
  yarn add @sberdevices/showcase@0.42.0-canary.627.45dee6832de7942c62c9625b63e4dde665c7bf3c.0
  yarn add @sberdevices/demo-canvas-app@0.14.0-canary.627.45dee6832de7942c62c9625b63e4dde665c7bf3c.0
  yarn add @sberdevices/plasma-icons@1.32.0-canary.627.45dee6832de7942c62c9625b63e4dde665c7bf3c.0
  yarn add @sberdevices/plasma-ui@1.37.0-canary.627.45dee6832de7942c62c9625b63e4dde665c7bf3c.0
  yarn add @sberdevices/plasma-web@1.36.0-canary.627.45dee6832de7942c62c9625b63e4dde665c7bf3c.0
  yarn add @sberdevices/plasma-sb-utils@0.16.0-canary.627.45dee6832de7942c62c9625b63e4dde665c7bf3c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
