### PR TITLE
feat: `Dropdown` color, icon; fix: `Dropdown` radius, shadow

### DIFF
--- a/packages/plasma-web/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/plasma-web/src/components/Dropdown/Dropdown.stories.tsx
@@ -28,6 +28,11 @@ export default {
 const StyledWrapper = styled.div`
     width: 13.75rem;
 `;
+const StyledRadialWrapper = styled(StyledWrapper)`
+    --plasma-dropdown-padding: 0.25rem;
+    --plasma-dropdown-border-radius: 1rem;
+    --plasma-dropdown-item-border-radius: 0.75rem;
+`;
 const StyledHeaderRoot = styled.header`
     margin: -1rem -1rem 0;
     background: ${background};
@@ -77,6 +82,17 @@ export const Default = () => {
                 ))}
             </DropdownList>
         </StyledWrapper>
+    );
+};
+export const Radius = () => {
+    return (
+        <StyledRadialWrapper>
+            <DropdownList>
+                {items.map((item) => (
+                    <DropdownItem key={item.value} {...item} />
+                ))}
+            </DropdownList>
+        </StyledRadialWrapper>
     );
 };
 export const LiveDemo = () => {

--- a/packages/plasma-web/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/plasma-web/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,6 +1,14 @@
 import React from 'react';
 import styled from 'styled-components';
-import { background } from '@sberdevices/plasma-core';
+import { background, accent, success, warning, critical } from '@sberdevices/plasma-core';
+import {
+    IconEye,
+    IconMagicWand,
+    IconAccessibility,
+    IconHeart,
+    IconTrash,
+    IconLocation,
+} from '@sberdevices/plasma-icons';
 
 import { InSpacingDecorator } from '../../helpers';
 import { Button } from '../Button';
@@ -37,29 +45,34 @@ const StyledMenuButton = styled(Button)`
 
 const items = [
     { value: 'each', label: 'Каждый' },
-    { value: 'hunter', label: 'Охотник', isDisabled: true },
-    { value: 'wants', label: 'Желает' },
+    { value: 'hunter', label: 'Охотник' },
     {
-        value: 'toKnow',
-        label: 'Знать',
+        value: 'wants',
+        label: 'Желает',
+        contentLeft: <IconHeart color="inherit" />,
         items: [
             { value: '_fulllabel', label: 'Каждый охотник желает знать, где сидит фазан' },
             { value: '_thePheasant', label: 'Фазан' },
             { value: '_is', label: 'Сидит' },
         ],
     },
-    { value: 'where', label: 'Где' },
-    { value: 'is', label: 'Сидит' },
-    { value: 'thePheasant', label: 'Фазан' },
-    { value: 'fulllabel', label: 'Каждый охотник желает знать, где сидит фазан' },
+    { value: 'toKnow', label: 'Знать', isDisabled: true, contentLeft: <IconEye color="inherit" /> },
+    { value: 'where', label: 'Где', color: accent, contentLeft: <IconLocation color="inherit" /> },
+    { value: 'is', label: 'Сидит', color: success, contentLeft: <IconAccessibility color="inherit" /> },
+    { value: 'thePheasant', label: 'Фазан', color: warning, contentLeft: <IconMagicWand color="inherit" /> },
+    {
+        value: 'fulllabel',
+        label: 'Каждый охотник желает знать, где сидит фазан',
+        contentLeft: <IconTrash color="inherit" />,
+        color: critical,
+    },
 ];
-const flatList = items.map(({ value, label, isDisabled }) => ({ value, label, isDisabled }));
 
 export const Default = () => {
     return (
         <StyledWrapper>
             <DropdownList>
-                {flatList.map((item) => (
+                {items.map((item) => (
                     <DropdownItem key={item.value} {...item} />
                 ))}
             </DropdownList>

--- a/packages/plasma-web/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/plasma-web/src/components/Dropdown/Dropdown.types.ts
@@ -1,10 +1,13 @@
+import { ReactNode } from 'react';
+
 export interface DropdownItem {
     value: string | number;
     label: string;
+    color?: string;
+    contentLeft?: ReactNode;
 }
-
 export interface DropdownNode extends DropdownItem {
-    isActive?: boolean;
     items?: Array<DropdownNode>;
+    isActive?: boolean;
     isDisabled?: boolean;
 }

--- a/packages/plasma-web/src/components/Dropdown/DropdownItem.tsx
+++ b/packages/plasma-web/src/components/Dropdown/DropdownItem.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useRef, useCallback, useMemo } from 'react';
+import React, { FC, ReactNode, useRef, useCallback, useMemo } from 'react';
 import styled, { css } from 'styled-components';
 import {
     body1,
@@ -15,10 +15,12 @@ import { DropdownItem as DropdownItemType, DropdownNode as DropdownNodeType } fr
 
 export interface DropdownItemProps extends DropdownNodeType {
     isActive?: boolean;
+    color?: string;
+    contentLeft?: ReactNode;
     onClick?: (item: DropdownItemType) => void;
 }
 
-const StyledDropdownItem = styled.a<{ $disabled?: boolean }>`
+const StyledDropdownItem = styled.a<{ $disabled?: boolean; $color?: string }>`
     ${body1};
 
     display: flex;
@@ -31,7 +33,7 @@ const StyledDropdownItem = styled.a<{ $disabled?: boolean }>`
     border-radius: var(--plasma-dropdown-border-radius, 0);
 
     background-color: transparent;
-    color: ${primary};
+    color: ${({ $color }) => $color || primary};
     transition: background-color 0.3s ease-in-out;
     cursor: pointer;
 
@@ -56,6 +58,10 @@ const StyledDropdownItem = styled.a<{ $disabled?: boolean }>`
             }
         `}
     ${applyDisabled}
+`;
+const StyledContent = styled.div`
+    display: inline-flex;
+    margin-right: 0.375rem;
 `;
 const StyledText = styled.span`
     ${applyEllipsis}
@@ -87,8 +93,10 @@ export const DropdownItem: FC<DropdownItemProps> = ({
     value,
     label,
     isActive,
-    items = [],
     isDisabled,
+    color,
+    contentLeft,
+    items = [],
     onClick: onClickExternal,
     ...rest
 }) => {
@@ -133,7 +141,8 @@ export const DropdownItem: FC<DropdownItemProps> = ({
     );
 
     return (
-        <StyledDropdownItem ref={itemRef} $disabled={isDisabled} onClick={onClick} {...rest}>
+        <StyledDropdownItem ref={itemRef} $disabled={isDisabled} $color={color} onClick={onClick} {...rest}>
+            {contentLeft && <StyledContent>{contentLeft}</StyledContent>}
             {label && <StyledText>{label}</StyledText>}
             {contentRight}
         </StyledDropdownItem>

--- a/packages/plasma-web/src/components/Dropdown/DropdownItem.tsx
+++ b/packages/plasma-web/src/components/Dropdown/DropdownItem.tsx
@@ -30,7 +30,7 @@ const StyledDropdownItem = styled.a<{ $disabled?: boolean; $color?: string }>`
 
     height: 3rem;
     padding: 0.875rem 1rem;
-    border-radius: var(--plasma-dropdown-border-radius, 0);
+    border-radius: var(--plasma-dropdown-item-border-radius, 0);
 
     background-color: transparent;
     color: ${({ $color }) => $color || primary};

--- a/packages/plasma-web/src/components/Dropdown/DropdownList.tsx
+++ b/packages/plasma-web/src/components/Dropdown/DropdownList.tsx
@@ -12,7 +12,7 @@ export const DropdownList = styled.div`
     padding: var(--plasma-dropdown-padding, 0);
 
     background-color: var(--plasma-dropdown-background, ${backgroundPrimary});
-    box-shadow: 0 13px 28px rgba(155, 155, 155, 0.2);
+    box-shadow: 0 0.75rem 1.75rem rgba(0, 0, 0, 0.08);
     border-radius: var(--plasma-dropdown-border-radius, 0);
 
     transition: opacity 0.3s ease-in-out;

--- a/packages/plasma-web/src/components/Select/SelectView.tsx
+++ b/packages/plasma-web/src/components/Select/SelectView.tsx
@@ -37,6 +37,7 @@ const statuses = {
 const StyledDropdown = styled(Dropdown)`
     --plasma-dropdown-padding: 0.25rem;
     --plasma-dropdown-border-radius: 0.25rem;
+    --plasma-dropdown-item-border-radius: 0.25rem;
     display: flex;
     width: 100%;
 `;


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/demo-canvas-app@0.22.0-canary.683.68e24f8cb7d88ec7f8445b0e7f70693e6fd07956.0
  npm install @sberdevices/plasma-icons@1.39.0-canary.683.68e24f8cb7d88ec7f8445b0e7f70693e6fd07956.0
  npm install @sberdevices/plasma-ui@1.45.0-canary.683.68e24f8cb7d88ec7f8445b0e7f70693e6fd07956.0
  npm install @sberdevices/plasma-web@1.43.0-canary.683.68e24f8cb7d88ec7f8445b0e7f70693e6fd07956.0
  npm install @sberdevices/plasma-sb-utils@0.23.0-canary.683.68e24f8cb7d88ec7f8445b0e7f70693e6fd07956.0
  npm install @sberdevices/showcase@0.50.0-canary.683.68e24f8cb7d88ec7f8445b0e7f70693e6fd07956.0
  # or 
  yarn add @sberdevices/demo-canvas-app@0.22.0-canary.683.68e24f8cb7d88ec7f8445b0e7f70693e6fd07956.0
  yarn add @sberdevices/plasma-icons@1.39.0-canary.683.68e24f8cb7d88ec7f8445b0e7f70693e6fd07956.0
  yarn add @sberdevices/plasma-ui@1.45.0-canary.683.68e24f8cb7d88ec7f8445b0e7f70693e6fd07956.0
  yarn add @sberdevices/plasma-web@1.43.0-canary.683.68e24f8cb7d88ec7f8445b0e7f70693e6fd07956.0
  yarn add @sberdevices/plasma-sb-utils@0.23.0-canary.683.68e24f8cb7d88ec7f8445b0e7f70693e6fd07956.0
  yarn add @sberdevices/showcase@0.50.0-canary.683.68e24f8cb7d88ec7f8445b0e7f70693e6fd07956.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
