### PR TITLE
fix(plasma-tokens-b2c): Confusing `paragraph` and `inverse` colors in…

### DIFF
--- a/packages/plasma-tokens-b2c/design-language/src/DesignLanguage.ts
+++ b/packages/plasma-tokens-b2c/design-language/src/DesignLanguage.ts
@@ -33,8 +33,8 @@ const theme = {
     light_secondary: playgroundWebB2CTokens.colors.textIconsSecondary3,
     light_tertiary: playgroundWebB2CTokens.colors.textIconsTertiary3,
 
-    light_paragraph: playgroundWebB2CTokens.colors.textIconsParagraph,
-    light_inverse: playgroundWebB2CTokens.colors.textIconsInverse,
+    light_paragraph: playgroundWebB2CTokens.colors.textIconsParagraph1,
+    light_inverse: playgroundWebB2CTokens.colors.textIconsInverse1,
 
     light_accent: playgroundWebB2CTokens.colors.textIconsAccentBrand,
     light_success: playgroundWebB2CTokens.colors.textIconsStatusSuccess,
@@ -79,8 +79,8 @@ const theme = {
     dark_secondary: playgroundWebB2CTokens.colors.textIconsSecondary1,
     dark_tertiary: playgroundWebB2CTokens.colors.textIconsTertiary,
 
-    dark_paragraph: playgroundWebB2CTokens.colors.textIconsParagraph1,
-    dark_inverse: playgroundWebB2CTokens.colors.textIconsInverse1,
+    dark_paragraph: playgroundWebB2CTokens.colors.textIconsParagraph,
+    dark_inverse: playgroundWebB2CTokens.colors.textIconsInverse,
 
     dark_accent: playgroundWebB2CTokens.colors.textIconsAccentBrand1,
     dark_success: playgroundWebB2CTokens.colors.textIconsStatusSuccess1,


### PR DESCRIPTION
… themes
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-docs@0.1.1-canary.709.f84a888e4c657f75afa8e78e7cd9d1cd58515067.0
  npm install @sberdevices/demo-canvas-app@0.23.1-canary.709.f84a888e4c657f75afa8e78e7cd9d1cd58515067.0
  npm install @sberdevices/plasma-colors@0.1.1-canary.709.f84a888e4c657f75afa8e78e7cd9d1cd58515067.0
  npm install @sberdevices/plasma-core@1.27.2-canary.709.f84a888e4c657f75afa8e78e7cd9d1cd58515067.0
  npm install @sberdevices/plasma-icons@1.39.1-canary.709.f84a888e4c657f75afa8e78e7cd9d1cd58515067.0
  npm install @sberdevices/plasma-tokens-b2c@0.5.1-canary.709.f84a888e4c657f75afa8e78e7cd9d1cd58515067.0
  npm install @sberdevices/plasma-tokens-web@1.11.1-canary.709.f84a888e4c657f75afa8e78e7cd9d1cd58515067.0
  npm install @sberdevices/plasma-tokens@1.12.1-canary.709.f84a888e4c657f75afa8e78e7cd9d1cd58515067.0
  npm install @sberdevices/plasma-ui@1.46.1-canary.709.f84a888e4c657f75afa8e78e7cd9d1cd58515067.0
  npm install @sberdevices/plasma-web@1.44.1-canary.709.f84a888e4c657f75afa8e78e7cd9d1cd58515067.0
  npm install @sberdevices/plasma-sb-utils@0.24.1-canary.709.f84a888e4c657f75afa8e78e7cd9d1cd58515067.0
  npm install @sberdevices/plasma-tokens-android@2.19.1-canary.709.f84a888e4c657f75afa8e78e7cd9d1cd58515067.0
  npm install @sberdevices/plasma-tokens-ios-swift@2.19.1-canary.709.f84a888e4c657f75afa8e78e7cd9d1cd58515067.0
  npm install @sberdevices/showcase@0.51.1-canary.709.f84a888e4c657f75afa8e78e7cd9d1cd58515067.0
  # or 
  yarn add @sberdevices/plasma-docs@0.1.1-canary.709.f84a888e4c657f75afa8e78e7cd9d1cd58515067.0
  yarn add @sberdevices/demo-canvas-app@0.23.1-canary.709.f84a888e4c657f75afa8e78e7cd9d1cd58515067.0
  yarn add @sberdevices/plasma-colors@0.1.1-canary.709.f84a888e4c657f75afa8e78e7cd9d1cd58515067.0
  yarn add @sberdevices/plasma-core@1.27.2-canary.709.f84a888e4c657f75afa8e78e7cd9d1cd58515067.0
  yarn add @sberdevices/plasma-icons@1.39.1-canary.709.f84a888e4c657f75afa8e78e7cd9d1cd58515067.0
  yarn add @sberdevices/plasma-tokens-b2c@0.5.1-canary.709.f84a888e4c657f75afa8e78e7cd9d1cd58515067.0
  yarn add @sberdevices/plasma-tokens-web@1.11.1-canary.709.f84a888e4c657f75afa8e78e7cd9d1cd58515067.0
  yarn add @sberdevices/plasma-tokens@1.12.1-canary.709.f84a888e4c657f75afa8e78e7cd9d1cd58515067.0
  yarn add @sberdevices/plasma-ui@1.46.1-canary.709.f84a888e4c657f75afa8e78e7cd9d1cd58515067.0
  yarn add @sberdevices/plasma-web@1.44.1-canary.709.f84a888e4c657f75afa8e78e7cd9d1cd58515067.0
  yarn add @sberdevices/plasma-sb-utils@0.24.1-canary.709.f84a888e4c657f75afa8e78e7cd9d1cd58515067.0
  yarn add @sberdevices/plasma-tokens-android@2.19.1-canary.709.f84a888e4c657f75afa8e78e7cd9d1cd58515067.0
  yarn add @sberdevices/plasma-tokens-ios-swift@2.19.1-canary.709.f84a888e4c657f75afa8e78e7cd9d1cd58515067.0
  yarn add @sberdevices/showcase@0.51.1-canary.709.f84a888e4c657f75afa8e78e7cd9d1cd58515067.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
