### PR TITLE
fix(plasma-ui): Added `coverGradient` prop to `CardContent`

### DIFF
--- a/packages/plasma-ui/src/components/Card/Card.stories.tsx
+++ b/packages/plasma-ui/src/components/Card/Card.stories.tsx
@@ -36,7 +36,7 @@ export const BasicValue: Story<BasicValueProps> = ({ outlined, scaleOnFocus, cov
                     placeholder="./images/320_320_1.jpg"
                     ratio={cover ? '1 / 1' : '16 / 9'}
                 />
-                <CardContent cover={cover}>
+                <CardContent cover={cover as true} coverGradient={cover && boolean('coverGradient', true)}>
                     <TextBox>
                         <TextBoxBigTitle>{subTitle}</TextBoxBigTitle>
                         <TextBoxBiggerTitle>{title}</TextBoxBiggerTitle>

--- a/packages/plasma-ui/src/components/Card/CardContent.tsx
+++ b/packages/plasma-ui/src/components/Card/CardContent.tsx
@@ -1,10 +1,30 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
+import { DisabledProps } from '@sberdevices/plasma-core';
 
-interface StyledRootProps {
-    cover?: boolean;
-    disabled?: boolean;
+interface CoverProps {
+    /**
+     * Контент перекрывает собой картинку.
+     */
+    cover?: true;
+    /**
+     * Градиент контента.
+     */
+    coverGradient?: boolean;
+}
+interface NoCoverProps {
+    cover?: false;
+    coverGradient?: never;
+}
+interface OtherProps extends DisabledProps {
     compact?: boolean;
+}
+
+export type CardContentProps = (CoverProps | NoCoverProps) & OtherProps & React.HTMLAttributes<HTMLDivElement>;
+
+interface StyledRootProps extends OtherProps {
+    cover?: boolean;
+    coverGradient?: boolean;
 }
 
 const StyledRoot = styled.div<StyledRootProps>`
@@ -24,7 +44,7 @@ const StyledRoot = styled.div<StyledRootProps>`
             opacity: 0.5;
         `}
 
-    ${({ cover }) =>
+    ${({ cover, coverGradient }) =>
         cover &&
         css`
             position: absolute;
@@ -35,18 +55,19 @@ const StyledRoot = styled.div<StyledRootProps>`
 
             justify-content: flex-end;
 
-            background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.74) 100%);
+            ${coverGradient &&
+            css`
+                background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.74) 100%);
+            `};
         `}
 `;
-
-export interface CardContentProps extends StyledRootProps, React.HTMLAttributes<HTMLDivElement> {}
 
 /**
  * Компонент для отображения как текстового, так и любого другого контента.
  */
-export const CardContent: React.FC<CardContentProps> = ({ disabled, cover, compact, className, children, ...rest }) => {
+export const CardContent: React.FC<CardContentProps> = ({ cover, coverGradient = true, children, ...rest }) => {
     return (
-        <StyledRoot cover={cover} compact={compact} disabled={disabled} className={className} {...rest}>
+        <StyledRoot cover={cover} coverGradient={coverGradient} {...rest}>
             {children}
         </StyledRoot>
     );


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-docs@0.2.1-canary.716.4da691138b44ff7d90818a524b1ccf785412f855.0
  npm install @sberdevices/demo-canvas-app@0.24.1-canary.716.4da691138b44ff7d90818a524b1ccf785412f855.0
  npm install @sberdevices/plasma-tokens-b2c@0.6.1-canary.716.4da691138b44ff7d90818a524b1ccf785412f855.0
  npm install @sberdevices/plasma-tokens-web@1.12.1-canary.716.4da691138b44ff7d90818a524b1ccf785412f855.0
  npm install @sberdevices/plasma-ui@1.47.1-canary.716.4da691138b44ff7d90818a524b1ccf785412f855.0
  npm install @sberdevices/plasma-web@1.45.1-canary.716.4da691138b44ff7d90818a524b1ccf785412f855.0
  npm install @sberdevices/plasma-sb-utils@0.25.1-canary.716.4da691138b44ff7d90818a524b1ccf785412f855.0
  npm install @sberdevices/plasma-tokens-android@2.20.1-canary.716.4da691138b44ff7d90818a524b1ccf785412f855.0
  npm install @sberdevices/plasma-tokens-ios-swift@2.20.1-canary.716.4da691138b44ff7d90818a524b1ccf785412f855.0
  npm install @sberdevices/showcase@0.52.1-canary.716.4da691138b44ff7d90818a524b1ccf785412f855.0
  # or 
  yarn add @sberdevices/plasma-docs@0.2.1-canary.716.4da691138b44ff7d90818a524b1ccf785412f855.0
  yarn add @sberdevices/demo-canvas-app@0.24.1-canary.716.4da691138b44ff7d90818a524b1ccf785412f855.0
  yarn add @sberdevices/plasma-tokens-b2c@0.6.1-canary.716.4da691138b44ff7d90818a524b1ccf785412f855.0
  yarn add @sberdevices/plasma-tokens-web@1.12.1-canary.716.4da691138b44ff7d90818a524b1ccf785412f855.0
  yarn add @sberdevices/plasma-ui@1.47.1-canary.716.4da691138b44ff7d90818a524b1ccf785412f855.0
  yarn add @sberdevices/plasma-web@1.45.1-canary.716.4da691138b44ff7d90818a524b1ccf785412f855.0
  yarn add @sberdevices/plasma-sb-utils@0.25.1-canary.716.4da691138b44ff7d90818a524b1ccf785412f855.0
  yarn add @sberdevices/plasma-tokens-android@2.20.1-canary.716.4da691138b44ff7d90818a524b1ccf785412f855.0
  yarn add @sberdevices/plasma-tokens-ios-swift@2.20.1-canary.716.4da691138b44ff7d90818a524b1ccf785412f855.0
  yarn add @sberdevices/showcase@0.52.1-canary.716.4da691138b44ff7d90818a524b1ccf785412f855.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
