### PR TITLE
feat(plasma-ui, plasma-core): Added `forwardedAs` and `as` props to `Tabs`

### DIFF
--- a/docs/docs/ui/components/Tabs.mdx
+++ b/docs/docs/ui/components/Tabs.mdx
@@ -8,7 +8,6 @@ import { Description } from '@site/src/components/Description';
 
 # Tabs
 Набор компонентов для создания вкладок.
-Структура для вкладок похожа на структуру маркированных списков.
 
 ```tsx live
 () => {
@@ -52,3 +51,20 @@ import { Description } from '@site/src/components/Description';
 Элемент списка. Нельзя использовать вне компонента `Tabs`.
 
 <PropsTable name="TabItem" />
+
+## Смена тега
+По умолчанию компоненты вкладок используют теги `<div>` и `<button>` для `Tabs` и `TabItem` соответственно.
+Иногда может понадобиться сменить эти теги на теги маркированных списков `<ul>` и `<li>`.
+Чтобы сделать это, используйте свойство `forwardedAs`:
+
+```tsx live
+<Tabs forwardedAs="ul">
+    <TabItem isActive forwardedAs="li">Каждый</TabItem>
+    <TabItem forwardedAs="li">Охотник</TabItem>
+    <TabItem forwardedAs="li">Желает</TabItem>
+    <TabItem forwardedAs="li">Знать</TabItem>
+    <TabItem forwardedAs="li">Где</TabItem>
+    <TabItem forwardedAs="li">Сидит</TabItem>
+    <TabItem forwardedAs="li">Фазан</TabItem>
+</Tabs>
+```

--- a/packages/plasma-core/src/components/Tabs/Tabs.tsx
+++ b/packages/plasma-core/src/components/Tabs/Tabs.tsx
@@ -3,8 +3,9 @@ import styled, { css } from 'styled-components';
 
 import { applyDisabled } from '../../mixins';
 import type { DisabledProps } from '../../mixins';
+import type { AsProps } from '../../types';
 
-export interface TabsProps extends DisabledProps, React.HTMLAttributes<HTMLDivElement> {
+export interface TabsProps extends AsProps, DisabledProps, React.HTMLAttributes<HTMLDivElement> {
     /**
      * Кнопки табов примут фиксированную ширину,
      * максимально равную 25% контейнера Tabs,

--- a/packages/plasma-ui/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/plasma-ui/src/components/Tabs/Tabs.stories.tsx
@@ -75,10 +75,12 @@ export const Default: Story<DefaultStoryProps & TabsProps> = ({
             disabled={disabled}
             index={index}
             animated={animated}
+            forwardedAs="ul"
         >
             {items.map((_, i) => (
                 <TabItem
                     key={`item:${i}`}
+                    forwardedAs="li"
                     isActive={i === index}
                     aria-controls={id}
                     tabIndex={0}

--- a/packages/plasma-ui/src/components/Tabs/Tabs.tsx
+++ b/packages/plasma-ui/src/components/Tabs/Tabs.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import type { TabsProps as BaseProps } from '@sberdevices/plasma-core';
 
 import { TabsContainer, TabsContainerProps } from './TabsContainer';
 import { TabItemAnimated } from './TabItem';
@@ -15,7 +16,7 @@ interface UnAnimatedProps {
     index?: never;
 }
 
-export type TabsProps = (AnimatedProps | UnAnimatedProps) & TabsContainerProps;
+export type TabsProps = (AnimatedProps | UnAnimatedProps) & BaseProps & TabsContainerProps;
 
 const isAnimatedProps = (props: TabsProps): props is AnimatedProps & TabsContainerProps => {
     return props.animated === true;


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-docs@0.0.1-canary.724.2482a64937b72da54ca6f748ce431153d4d5ab8f.0
  npm install @sberdevices/demo-canvas-app@0.22.1-canary.724.2482a64937b72da54ca6f748ce431153d4d5ab8f.0
  npm install @sberdevices/plasma-core@1.27.2-canary.724.2482a64937b72da54ca6f748ce431153d4d5ab8f.0
  npm install @sberdevices/plasma-icons@1.39.1-canary.724.2482a64937b72da54ca6f748ce431153d4d5ab8f.0
  npm install @sberdevices/plasma-ui@1.45.1-canary.724.2482a64937b72da54ca6f748ce431153d4d5ab8f.0
  npm install @sberdevices/plasma-web@1.43.1-canary.724.2482a64937b72da54ca6f748ce431153d4d5ab8f.0
  npm install @sberdevices/extract-sb-docgen-info@0.0.1-canary.724.2482a64937b72da54ca6f748ce431153d4d5ab8f.0
  npm install @sberdevices/plasma-sb-utils@0.23.1-canary.724.2482a64937b72da54ca6f748ce431153d4d5ab8f.0
  npm install @sberdevices/showcase@0.50.1-canary.724.2482a64937b72da54ca6f748ce431153d4d5ab8f.0
  # or 
  yarn add @sberdevices/plasma-docs@0.0.1-canary.724.2482a64937b72da54ca6f748ce431153d4d5ab8f.0
  yarn add @sberdevices/demo-canvas-app@0.22.1-canary.724.2482a64937b72da54ca6f748ce431153d4d5ab8f.0
  yarn add @sberdevices/plasma-core@1.27.2-canary.724.2482a64937b72da54ca6f748ce431153d4d5ab8f.0
  yarn add @sberdevices/plasma-icons@1.39.1-canary.724.2482a64937b72da54ca6f748ce431153d4d5ab8f.0
  yarn add @sberdevices/plasma-ui@1.45.1-canary.724.2482a64937b72da54ca6f748ce431153d4d5ab8f.0
  yarn add @sberdevices/plasma-web@1.43.1-canary.724.2482a64937b72da54ca6f748ce431153d4d5ab8f.0
  yarn add @sberdevices/extract-sb-docgen-info@0.0.1-canary.724.2482a64937b72da54ca6f748ce431153d4d5ab8f.0
  yarn add @sberdevices/plasma-sb-utils@0.23.1-canary.724.2482a64937b72da54ca6f748ce431153d4d5ab8f.0
  yarn add @sberdevices/showcase@0.50.1-canary.724.2482a64937b72da54ca6f748ce431153d4d5ab8f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
