### PR TITLE
fix: Disabled state for `Checkbox` and `Radiobox`

### DIFF
--- a/packages/plasma-ui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/plasma-ui/src/components/Checkbox/Checkbox.tsx
@@ -127,7 +127,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(function Che
 ) {
     return (
         <StyledRoot $disabled={disabled} style={style} className={className} htmlFor={id}>
-            <BaseboxInput id={id} ref={ref} type="checkbox" {...rest} />
+            <BaseboxInput id={id} ref={ref} type="checkbox" disabled={disabled} {...rest} />
             <StyledTrigger $focused={focused} $scaleOnInteraction={scaleOnInteraction}>
                 <StyledMark color="inherit" size="xs" />
             </StyledTrigger>

--- a/packages/plasma-ui/src/components/Radiobox/Radiobox.tsx
+++ b/packages/plasma-ui/src/components/Radiobox/Radiobox.tsx
@@ -46,7 +46,7 @@ export const Radiobox = forwardRef<HTMLInputElement, RadioboxProps>(function Rad
 ) {
     return (
         <CheckboxRoot $disabled={disabled} style={style} className={className} htmlFor={id}>
-            <BaseboxInput id={id} ref={ref} type="radio" {...rest} />
+            <BaseboxInput id={id} ref={ref} type="radio" disabled={disabled} {...rest} />
             <StyledTrigger $focused={focused} $scaleOnInteraction={scaleOnInteraction}>
                 <StyledEllipse />
             </StyledTrigger>

--- a/packages/plasma-web/src/components/Checkbox/Checkbox.tsx
+++ b/packages/plasma-web/src/components/Checkbox/Checkbox.tsx
@@ -75,14 +75,14 @@ export const StyledTrigger = styled(BaseboxTrigger)`
 `;
 export const StyledContent = styled(BaseboxContent)`
     margin-left: 0.875rem;
+
+    /* stylelint-disable-next-line */
+    input:disabled ~ & {
+        opacity: 0.4;
+    }
 `;
 export const StyledLabel = styled(BaseboxLabel)`
     line-height: 1.5rem;
-
-    /* stylelint-disable-next-line */
-    input:disabled ~ ${StyledContent} & {
-        opacity: 0.4;
-    }
 `;
 export const StyledDescription = styled(BaseboxDescription)`
     /* stylelint-disable-next-line */
@@ -128,7 +128,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(function Che
 
     return (
         <StyledRoot $disabled={disabled} style={style} className={className} htmlFor={id}>
-            <BaseboxInput id={id} ref={forkRef} type="checkbox" {...rest} />
+            <BaseboxInput id={id} ref={forkRef} type="checkbox" disabled={disabled} {...rest} />
             <StyledTrigger>{indeterminate ? <StyledIndeterminate /> : <StyledDone />}</StyledTrigger>
             {label && (
                 <StyledContent>


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-docs@0.1.3-canary.791.5cbd912667f09ae3819c685b21e62746d3f9a96d.0
  npm install @sberdevices/demo-canvas-app@0.23.3-canary.791.5cbd912667f09ae3819c685b21e62746d3f9a96d.0
  npm install @sberdevices/plasma-icons@1.39.3-canary.791.5cbd912667f09ae3819c685b21e62746d3f9a96d.0
  npm install @sberdevices/plasma-ui@1.46.3-canary.791.5cbd912667f09ae3819c685b21e62746d3f9a96d.0
  npm install @sberdevices/plasma-web@1.44.3-canary.791.5cbd912667f09ae3819c685b21e62746d3f9a96d.0
  npm install @sberdevices/plasma-sb-utils@0.24.3-canary.791.5cbd912667f09ae3819c685b21e62746d3f9a96d.0
  npm install @sberdevices/showcase@0.51.3-canary.791.5cbd912667f09ae3819c685b21e62746d3f9a96d.0
  # or 
  yarn add @sberdevices/plasma-docs@0.1.3-canary.791.5cbd912667f09ae3819c685b21e62746d3f9a96d.0
  yarn add @sberdevices/demo-canvas-app@0.23.3-canary.791.5cbd912667f09ae3819c685b21e62746d3f9a96d.0
  yarn add @sberdevices/plasma-icons@1.39.3-canary.791.5cbd912667f09ae3819c685b21e62746d3f9a96d.0
  yarn add @sberdevices/plasma-ui@1.46.3-canary.791.5cbd912667f09ae3819c685b21e62746d3f9a96d.0
  yarn add @sberdevices/plasma-web@1.44.3-canary.791.5cbd912667f09ae3819c685b21e62746d3f9a96d.0
  yarn add @sberdevices/plasma-sb-utils@0.24.3-canary.791.5cbd912667f09ae3819c685b21e62746d3f9a96d.0
  yarn add @sberdevices/showcase@0.51.3-canary.791.5cbd912667f09ae3819c685b21e62746d3f9a96d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
