### PR TITLE
fix(plasma-temple): Fix Layout scroll

### DIFF
--- a/packages/plasma-temple/src/components/Layout/Layout.tsx
+++ b/packages/plasma-temple/src/components/Layout/Layout.tsx
@@ -5,6 +5,8 @@ import styled, { CSSObject } from 'styled-components';
 import { Insets, useInsets } from '../../hooks';
 import { AssistantInsets } from '../../store';
 
+import { LayoutElementContext } from './LayoutElementContext';
+
 interface LayoutProps {
     ignoreInsets?: boolean;
 }
@@ -47,10 +49,13 @@ const defaultInsets: Insets = {
 
 export const Layout: React.FC<LayoutProps> = ({ children, ignoreInsets }) => {
     const insets = useInsets();
+    const scrollableElementRef = React.useRef<HTMLDivElement>(null);
 
     return (
-        <StyledLayout insets={ignoreInsets ? defaultInsets : insets}>
-            <Container>{children}</Container>
-        </StyledLayout>
+        <LayoutElementContext.Provider value={scrollableElementRef.current}>
+            <StyledLayout insets={ignoreInsets ? defaultInsets : insets} ref={scrollableElementRef}>
+                <Container>{children}</Container>
+            </StyledLayout>
+        </LayoutElementContext.Provider>
     );
 };

--- a/packages/plasma-temple/src/components/Layout/LayoutElementContext.ts
+++ b/packages/plasma-temple/src/components/Layout/LayoutElementContext.ts
@@ -1,0 +1,5 @@
+import React from 'react';
+
+type LayoutElementValue = HTMLDivElement | null;
+
+export const LayoutElementContext = React.createContext<LayoutElementValue>(null);

--- a/packages/plasma-temple/src/pages/GridPage/GridPage.tsx
+++ b/packages/plasma-temple/src/pages/GridPage/GridPage.tsx
@@ -9,6 +9,7 @@ import { useSpatNavBetweenTargets } from '../../hooks/useSpatNav';
 import { useVoiceNavigationWithSpatNav } from '../../hooks/useVoiceNavigation';
 import { scroll } from '../../utils/scroll';
 import { FullScreenBackground } from '../ItemPage/components/FullScreenBackground/FullScreenBackground';
+import { LayoutElementContext } from '../../components/Layout/LayoutElementContext';
 
 import { GridEntity, GridPageState } from './types';
 import { GridCard, GridCardProps } from './components/GridCard';
@@ -21,13 +22,16 @@ interface GridPageProps {
     children?(props: GridCardProps & { key: string }): JSX.Element;
 }
 
-const scrollToWithOffset = (offset: number) => {
+const scrollToWithOffset = (offset: number, element: HTMLDivElement | null) => {
     const targetOffset = offset <= 250 ? 0 : offset - 250;
+    if (!element) {
+        return;
+    }
 
     scroll({
-        element: window,
-        startPosition: window.scrollY,
-        offset: targetOffset - window.scrollY,
+        element,
+        startPosition: element.scrollTop,
+        offset: targetOffset - element.scrollTop,
         duration: 300,
         axis: 'y',
     });
@@ -39,6 +43,7 @@ const ContentSection = styled.section`
 
 export const GridPage: React.FC<GridPageProps> = ({ state, header, onItemShow, onScrollBottom, children }) => {
     const { items, background } = state;
+    const layoutElementContext = React.useContext(LayoutElementContext);
 
     const list = React.useMemo(
         () =>
@@ -54,7 +59,7 @@ export const GridPage: React.FC<GridPageProps> = ({ state, header, onItemShow, o
     );
 
     useVoiceNavigationWithSpatNav({ axis: 'y', main: true });
-    useSpatNavBetweenTargets<HTMLElement>('y', ({ offsetTop }) => scrollToWithOffset(offsetTop));
+    useSpatNavBetweenTargets<HTMLElement>('y', ({ offsetTop }) => scrollToWithOffset(offsetTop, layoutElementContext));
 
     // Необходимо сбросить первоночально установленную точку, чтобы старт навигации был с сфокусированного элемента
     React.useEffect(() => {

--- a/packages/plasma-temple/src/pages/ItemPage/ItemPage.tsx
+++ b/packages/plasma-temple/src/pages/ItemPage/ItemPage.tsx
@@ -7,6 +7,7 @@ import { useSpatNav } from '../../hooks/useSpatNav';
 import { useVoiceNavigationWithSpatNav } from '../../hooks/useVoiceNavigation';
 import { scroll } from '../../utils/scroll';
 import { getMediaObjectSrc } from '../../utils';
+import { LayoutElementContext } from '../../components/Layout/LayoutElementContext';
 
 import { ItemEntityProps } from './components/ItemEntity/ItemEntity';
 import { ItemPageState } from './types';
@@ -19,13 +20,16 @@ interface ItemPageProps {
     entityComponent?: React.ComponentType<ItemEntityProps>;
 }
 
-const scrollToWithOffset = (offset: number) => {
+const scrollToWithOffset = (offset: number, element: HTMLDivElement | null) => {
     const targetOffset = offset <= 0 ? offset : offset - 100;
+    if (!element) {
+        return;
+    }
 
     scroll({
-        element: window,
-        startPosition: window.scrollY,
-        offset: targetOffset - window.scrollY,
+        element,
+        startPosition: element.scrollTop,
+        offset: targetOffset - element.scrollTop,
         duration: 300,
         axis: 'y',
     });
@@ -34,6 +38,7 @@ const scrollToWithOffset = (offset: number) => {
 export const ItemPage: React.FC<ItemPageProps> = ({ state, header, entityComponent, onItemShow, onItemFocus }) => {
     const { entities, entitiesTitle, background, title, subtitle, description, actionButtonText } = state;
     const { ItemMainSection, ItemEntities } = useRegistry();
+    const layoutElementContext = React.useContext(LayoutElementContext);
 
     const list = React.useMemo(
         () =>
@@ -54,7 +59,7 @@ export const ItemPage: React.FC<ItemPageProps> = ({ state, header, entityCompone
     );
 
     useVoiceNavigationWithSpatNav({ axis: 'y', main: true });
-    useSpatNav<HTMLElement>(({ offsetTop }) => scrollToWithOffset(offsetTop));
+    useSpatNav<HTMLElement>(({ offsetTop }) => scrollToWithOffset(offsetTop, layoutElementContext));
 
     // Необходимо сбросить первоночально установленную точку, чтобы старт навигации был с сфокусированного элемента
     React.useEffect(() => {


### PR DESCRIPTION
Исправил скролл на страницах `GridPage` и `ItemPage`. Проблема была в том, что теперь у нас скролл страницы на элементе `Layout`, а раньше было на `window`.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-b2c@1.4.1-canary.815.70ea98309f365382c3215538dc4f9716041af1d3.0
  npm install @sberdevices/plasma-temple@1.1.2-canary.815.70ea98309f365382c3215538dc4f9716041af1d3.0
  npm install @sberdevices/plasma-web@1.49.1-canary.815.70ea98309f365382c3215538dc4f9716041af1d3.0
  npm install @sberdevices/showcase@0.56.1-canary.815.70ea98309f365382c3215538dc4f9716041af1d3.0
  npm install @sberdevices/plasma-ui-docs@0.6.1-canary.815.70ea98309f365382c3215538dc4f9716041af1d3.0
  npm install @sberdevices/plasma-web-docs@0.3.1-canary.815.70ea98309f365382c3215538dc4f9716041af1d3.0
  # or 
  yarn add @sberdevices/plasma-b2c@1.4.1-canary.815.70ea98309f365382c3215538dc4f9716041af1d3.0
  yarn add @sberdevices/plasma-temple@1.1.2-canary.815.70ea98309f365382c3215538dc4f9716041af1d3.0
  yarn add @sberdevices/plasma-web@1.49.1-canary.815.70ea98309f365382c3215538dc4f9716041af1d3.0
  yarn add @sberdevices/showcase@0.56.1-canary.815.70ea98309f365382c3215538dc4f9716041af1d3.0
  yarn add @sberdevices/plasma-ui-docs@0.6.1-canary.815.70ea98309f365382c3215538dc4f9716041af1d3.0
  yarn add @sberdevices/plasma-web-docs@0.3.1-canary.815.70ea98309f365382c3215538dc4f9716041af1d3.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
