### PR TITLE
ci: fix failing of pkg-locks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Update package-lock's
         if: github.event_name != 'pull_request'
-        run: lerna clean -y && lerna exec -- npm i --package-lock-only
+        run: lerna clean -y && lerna exec --no-private -- npm i --package-lock-only
 
       - name: Extract branch name
         if: github.event_name != 'pull_request'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Update package-lock's
         if: github.event_name != 'pull_request'
-        run: lerna clean -y && lerna exec --no-private -- npm i --package-lock-only
+        run: lerna clean -y && lerna exec --ignore @sberdevices/plasma-ui-docs --ignore @sberdevices/plasma-web-docs -- npm i --package-lock-only
 
       - name: Extract branch name
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
cc @fanisco 

пытаюсь решить проблему падений:

```
found 5424 vulnerabilities (9 low, 1163 moderate, 4252 high)
  run `npm audit fix` to fix them, or `npm audit` for details
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/@sberdevices%2fplasma-docs-ui - Not found
npm ERR! 404 
npm ERR! 404  '@sberdevices/plasma-docs-ui@0.0.1' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
npm ERR! 404 It was specified as a dependency of 'plasma-web-docs'
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2021-09-24T10_09_09_019Z-debug.log
lerna ERR! npm i --package-lock-only exited 1 in '@sberdevices/plasma-web-docs'
lerna ERR! npm i --package-lock-only exited 1 in '@sberdevices/plasma-web-docs'
```


