### PR TITLE
fix(plasma-ui): `HeaderContent` flex in Chrome 94

### DIFF
--- a/packages/plasma-ui/src/components/Header/HeaderContent.tsx
+++ b/packages/plasma-ui/src/components/Header/HeaderContent.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import styled from 'styled-components';
 
 const StyledHeaderContent = styled.div`
+    display: flex;
+    justify-content: flex-end;
     flex: 1 0 max-content;
     margin-left: auto;
     padding-left: 0.75rem;


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/demo-canvas-app@0.33.1-canary.875.43349798cc2502d9edae76da43d6bbfbc695b080.0
  npm install @sberdevices/plasma-ui@1.56.1-canary.875.43349798cc2502d9edae76da43d6bbfbc695b080.0
  npm install @sberdevices/showcase@0.64.1-canary.875.43349798cc2502d9edae76da43d6bbfbc695b080.0
  npm install @sberdevices/plasma-ui-docs@0.11.1-canary.875.43349798cc2502d9edae76da43d6bbfbc695b080.0
  # or 
  yarn add @sberdevices/demo-canvas-app@0.33.1-canary.875.43349798cc2502d9edae76da43d6bbfbc695b080.0
  yarn add @sberdevices/plasma-ui@1.56.1-canary.875.43349798cc2502d9edae76da43d6bbfbc695b080.0
  yarn add @sberdevices/showcase@0.64.1-canary.875.43349798cc2502d9edae76da43d6bbfbc695b080.0
  yarn add @sberdevices/plasma-ui-docs@0.11.1-canary.875.43349798cc2502d9edae76da43d6bbfbc695b080.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
