### PR TITLE
fix: headers font weight fix

### DIFF
--- a/packages/plasma-typo/src/standard.ts
+++ b/packages/plasma-typo/src/standard.ts
@@ -285,27 +285,27 @@ const typoL = {
     },
     h1: {
         'font-size': '3rem',
-        'font-weight': '400',
+        'font-weight': '600',
         'line-height': '3.375rem',
     },
     h2: {
         'font-size': '2rem',
-        'font-weight': '400',
+        'font-weight': '600',
         'line-height': '2.375rem',
     },
     h3: {
         'font-size': '1.5rem',
-        'font-weight': '400',
+        'font-weight': '600',
         'line-height': '1.875rem',
     },
     h4: {
         'font-size': '1.25rem',
-        'font-weight': '400',
+        'font-weight': '600',
         'line-height': '1.625rem',
     },
     h5: {
         'font-size': '1.125rem',
-        'font-weight': '400',
+        'font-weight': '600',
         'line-height': '1.5rem',
     },
     'body-l': {


### PR DESCRIPTION
Фикс жирности заголовков для плазмы b2c
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/demo-canvas-app@0.35.2-canary.889.816d3bda31ea00c9549396b77e7c15b1fe023a0c.0
  npm install @sberdevices/plasma-b2c@1.13.2-canary.889.816d3bda31ea00c9549396b77e7c15b1fe023a0c.0
  npm install @sberdevices/plasma-core@1.33.3-canary.889.816d3bda31ea00c9549396b77e7c15b1fe023a0c.0
  npm install @sberdevices/plasma-icons@1.48.1-canary.889.816d3bda31ea00c9549396b77e7c15b1fe023a0c.0
  npm install @sberdevices/plasma-typo@0.2.1-canary.889.816d3bda31ea00c9549396b77e7c15b1fe023a0c.0
  npm install @sberdevices/plasma-ui@1.58.2-canary.889.816d3bda31ea00c9549396b77e7c15b1fe023a0c.0
  npm install @sberdevices/plasma-web@1.54.2-canary.889.816d3bda31ea00c9549396b77e7c15b1fe023a0c.0
  npm install @sberdevices/plasma-cy-utils@0.3.2-canary.889.816d3bda31ea00c9549396b77e7c15b1fe023a0c.0
  npm install @sberdevices/plasma-sb-utils@0.32.3-canary.889.816d3bda31ea00c9549396b77e7c15b1fe023a0c.0
  npm install @sberdevices/showcase@0.66.3-canary.889.816d3bda31ea00c9549396b77e7c15b1fe023a0c.0
  npm install @sberdevices/plasma-ui-docs@0.13.4-canary.889.816d3bda31ea00c9549396b77e7c15b1fe023a0c.0
  npm install @sberdevices/plasma-web-docs@0.7.3-canary.889.816d3bda31ea00c9549396b77e7c15b1fe023a0c.0
  npm install @sberdevices/plasma-website@0.0.2-canary.889.816d3bda31ea00c9549396b77e7c15b1fe023a0c.0
  # or 
  yarn add @sberdevices/demo-canvas-app@0.35.2-canary.889.816d3bda31ea00c9549396b77e7c15b1fe023a0c.0
  yarn add @sberdevices/plasma-b2c@1.13.2-canary.889.816d3bda31ea00c9549396b77e7c15b1fe023a0c.0
  yarn add @sberdevices/plasma-core@1.33.3-canary.889.816d3bda31ea00c9549396b77e7c15b1fe023a0c.0
  yarn add @sberdevices/plasma-icons@1.48.1-canary.889.816d3bda31ea00c9549396b77e7c15b1fe023a0c.0
  yarn add @sberdevices/plasma-typo@0.2.1-canary.889.816d3bda31ea00c9549396b77e7c15b1fe023a0c.0
  yarn add @sberdevices/plasma-ui@1.58.2-canary.889.816d3bda31ea00c9549396b77e7c15b1fe023a0c.0
  yarn add @sberdevices/plasma-web@1.54.2-canary.889.816d3bda31ea00c9549396b77e7c15b1fe023a0c.0
  yarn add @sberdevices/plasma-cy-utils@0.3.2-canary.889.816d3bda31ea00c9549396b77e7c15b1fe023a0c.0
  yarn add @sberdevices/plasma-sb-utils@0.32.3-canary.889.816d3bda31ea00c9549396b77e7c15b1fe023a0c.0
  yarn add @sberdevices/showcase@0.66.3-canary.889.816d3bda31ea00c9549396b77e7c15b1fe023a0c.0
  yarn add @sberdevices/plasma-ui-docs@0.13.4-canary.889.816d3bda31ea00c9549396b77e7c15b1fe023a0c.0
  yarn add @sberdevices/plasma-web-docs@0.7.3-canary.889.816d3bda31ea00c9549396b77e7c15b1fe023a0c.0
  yarn add @sberdevices/plasma-website@0.0.2-canary.889.816d3bda31ea00c9549396b77e7c15b1fe023a0c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
