### PR TITLE
fix: upload progress rounding

### DIFF
--- a/packages/plasma-b2c/src/components/Upload/UploadProgress.tsx
+++ b/packages/plasma-b2c/src/components/Upload/UploadProgress.tsx
@@ -40,7 +40,7 @@ export interface UploadProgressProps {
 }
 
 export const UploadProgress: FC<UploadProgressProps> = ({ progress: rawProgress }) => {
-    const progress = Math.min(Math.max(rawProgress || 0, 0), 100);
+    const progress = Math.round(Math.min(Math.max(rawProgress || 0, 0), 100));
 
     return (
         <StyledRoot>


### PR DESCRIPTION
Фикс округления прогресса загрузки
![image](https://user-images.githubusercontent.com/7758731/138595207-42803447-397a-4ec6-8553-9c39c563224b.png)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-b2c@1.13.4-canary.891.3584a982ec9dc4aad40277ccbc0415683bb90f65.0
  npm install @sberdevices/showcase@0.66.5-canary.891.3584a982ec9dc4aad40277ccbc0415683bb90f65.0
  npm install @sberdevices/plasma-website@0.0.4-canary.891.3584a982ec9dc4aad40277ccbc0415683bb90f65.0
  # or 
  yarn add @sberdevices/plasma-b2c@1.13.4-canary.891.3584a982ec9dc4aad40277ccbc0415683bb90f65.0
  yarn add @sberdevices/showcase@0.66.5-canary.891.3584a982ec9dc4aad40277ccbc0415683bb90f65.0
  yarn add @sberdevices/plasma-website@0.0.4-canary.891.3584a982ec9dc4aad40277ccbc0415683bb90f65.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
