### PR TITLE
fix(plasma-ui): Fix scroll behavior and range values for `Picker` component

### DIFF
--- a/packages/plasma-ui/src/components/Pickers/PickerItem.tsx
+++ b/packages/plasma-ui/src/components/Pickers/PickerItem.tsx
@@ -23,6 +23,7 @@ const sizes = {
 
 interface StyledSizeProps {
     $size: keyof typeof sizes;
+    $noScrollBehavior: boolean;
 }
 
 export const StyledPickerItem = styled.div<StyledSizeProps>`
@@ -37,7 +38,12 @@ export const StyledPickerItem = styled.div<StyledSizeProps>`
 
     cursor: pointer;
     user-select: none;
-    scroll-snap-align: center;
+
+    ${({ $noScrollBehavior }) =>
+        !$noScrollBehavior &&
+        css`
+            scroll-snap-align: center;
+        `}
 
     &:focus {
         outline: 0 none;
@@ -52,8 +58,13 @@ const StyledTransformable = styled.div<StyledSizeProps>`
     height: 100%;
 
     flex-direction: column;
-    transition: transform 0.1s ease;
-    transform: translate3d(0, 0, 0);
+
+    ${({ $noScrollBehavior }) =>
+        !$noScrollBehavior &&
+        css`
+            transition: transform 0.1s ease;
+            transform: translate3d(0, 0, 0);
+        `}
 
     ${({ $size }) =>
         $size === 's'
@@ -82,9 +93,19 @@ export interface PickerItemProps extends React.HTMLAttributes<HTMLDivElement>, S
     item: Item;
     index: number;
     activeIndex: number;
+    noScrollBehavior: boolean;
+    onItemClick?: (item: Item) => void;
 }
 
-export const PickerItem: React.FC<PickerItemProps> = ({ size = 's', item, index, activeIndex, ...rest }) => {
+export const PickerItem: React.FC<PickerItemProps> = ({
+    size = 's',
+    item,
+    index,
+    activeIndex,
+    noScrollBehavior,
+    onItemClick,
+    ...rest
+}) => {
     const itemRef = useCarouselItem<HTMLDivElement>();
     /*
      * Выведем стили еще до того, как отработает коллбек стилей.
@@ -92,9 +113,13 @@ export const PickerItem: React.FC<PickerItemProps> = ({ size = 's', item, index,
      */
     const styles = React.useMemo(() => getStyles(index - activeIndex, size), [index, activeIndex, size]);
 
+    const onClick = React.useCallback(() => {
+        onItemClick?.(item);
+    }, [item]);
+
     return (
-        <StyledPickerItem ref={itemRef} $size={size} {...rest}>
-            <StyledTransformable $size={size} style={styles.wrapper}>
+        <StyledPickerItem $noScrollBehavior={noScrollBehavior} ref={itemRef} $size={size} onClick={onClick} {...rest}>
+            <StyledTransformable $noScrollBehavior={noScrollBehavior} $size={size} style={styles.wrapper}>
                 <StyledText style={styles.text}>{item.label}</StyledText>
                 <StyledWhiteText style={styles.whiteText}>{item.label}</StyledWhiteText>
             </StyledTransformable>

--- a/packages/plasma-ui/src/components/Pickers/TimePicker.tsx
+++ b/packages/plasma-ui/src/components/Pickers/TimePicker.tsx
@@ -174,15 +174,15 @@ export const TimePicker: React.FC<TimePickerProps> = ({
             minMins = minMinutes;
         }
 
-        if (minutes === minMinutes) {
-            minSecs = minSeconds;
-        }
-
         if (hours === maxHours) {
             maxMins = maxMinutes;
         }
 
-        if (minutes === maxMinutes) {
+        if (hours === minHours && minutes === minMinutes) {
+            minSecs = minSeconds;
+        }
+
+        if (hours === maxHours && minutes === maxMinutes) {
             maxSecs = maxSeconds;
         }
 

--- a/packages/plasma-ui/src/components/Pickers/utils.ts
+++ b/packages/plasma-ui/src/components/Pickers/utils.ts
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from 'react';
+
 import { Size } from './types';
 
 const sizes = {
@@ -219,4 +221,17 @@ export const getNormalizeValues = (
     }
 
     return curValues;
+};
+
+/**
+ * Хук для сохранения предыдущего значения
+ */
+export const usePreviousValue = (value: string | number | Date) => {
+    const ref = useRef<string | number | Date>();
+
+    useEffect(() => {
+        ref.current = value;
+    });
+
+    return ref.current;
 };


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/demo-canvas-app@0.37.1-canary.897.59e60c3025611aeff0ceaafbf7e74146c35da537.0
  npm install @sberdevices/plasma-ui@1.60.1-canary.897.59e60c3025611aeff0ceaafbf7e74146c35da537.0
  npm install @sberdevices/showcase@0.69.2-canary.897.59e60c3025611aeff0ceaafbf7e74146c35da537.0
  npm install @sberdevices/plasma-ui-docs@0.16.2-canary.897.59e60c3025611aeff0ceaafbf7e74146c35da537.0
  # or 
  yarn add @sberdevices/demo-canvas-app@0.37.1-canary.897.59e60c3025611aeff0ceaafbf7e74146c35da537.0
  yarn add @sberdevices/plasma-ui@1.60.1-canary.897.59e60c3025611aeff0ceaafbf7e74146c35da537.0
  yarn add @sberdevices/showcase@0.69.2-canary.897.59e60c3025611aeff0ceaafbf7e74146c35da537.0
  yarn add @sberdevices/plasma-ui-docs@0.16.2-canary.897.59e60c3025611aeff0ceaafbf7e74146c35da537.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
