### PR TITLE
feat(plasma-temple): export useHeaderProps

### DIFF
--- a/packages/plasma-temple/src/components/Header/Header.tsx
+++ b/packages/plasma-temple/src/components/Header/Header.tsx
@@ -4,6 +4,8 @@ import { Header as UIKitHeader } from '@sberdevices/plasma-ui';
 import { HeaderProps } from './types';
 import { useHeaderProps } from './useHeaderProps';
 
+export { useHeaderProps };
+
 export const Header: React.FC<HeaderProps> = (props) => {
     const headerProps = useHeaderProps(props);
 


### PR DESCRIPTION
Отдельно `useHeaderProps` нужен при создании кастомных заголовков
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-temple@1.4.0-canary.902.c99ecafdd3340eca85e00552da2ce876e53d69b1.0
  # or 
  yarn add @sberdevices/plasma-temple@1.4.0-canary.902.c99ecafdd3340eca85e00552da2ce876e53d69b1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
