### PR TITLE
fix: Separate `Input`'s animation by b2b and b2c

### DIFF
--- a/packages/plasma-core/src/components/TextField/TextField.tsx
+++ b/packages/plasma-core/src/components/TextField/TextField.tsx
@@ -87,8 +87,6 @@ const inputStyles = css`
     line-height: inherit;
     letter-spacing: inherit;
 
-    transition: background-color 0.1s ease-in-out, border-color 0.1s ease-in-out, box-shadow 0.1s ease-in-out;
-
     &:focus {
         outline: none;
     }

--- a/packages/plasma-ui/src/components/Field/Field.tsx
+++ b/packages/plasma-ui/src/components/Field/Field.tsx
@@ -7,6 +7,8 @@ export const FieldInput = styled.input<Pick<TextFieldProps, '$isFocused'>>`
     border-color: transparent;
     border-radius: 1rem;
 
+    transition: background-color 0.1s ease-in-out;
+
     &:focus:not(:read-only) {
         background-color: ${surfaceLiquid02};
     }

--- a/packages/plasma-web/src/components/Field/Field.tsx
+++ b/packages/plasma-web/src/components/Field/Field.tsx
@@ -43,6 +43,8 @@ export const FieldInput = styled.input<Pick<TextFieldProps, 'status'> & { $isFoc
     border-color: ${inputBorder};
     border-radius: 0.25rem;
 
+    transition: border-color 0.1s ease-in-out, box-shadow 0.1s ease-in-out;
+
     &:hover {
         border-color: ${inputBorderHover};
     }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/demo-canvas-app@0.40.1-canary.908.edee9289d5ff9b87cab19b020ce9414dcdeb17a4.0
  npm install @sberdevices/plasma-b2c@1.18.1-canary.908.edee9289d5ff9b87cab19b020ce9414dcdeb17a4.0
  npm install @sberdevices/plasma-core@1.35.2-canary.908.edee9289d5ff9b87cab19b020ce9414dcdeb17a4.0
  npm install @sberdevices/plasma-icons@1.51.2-canary.908.edee9289d5ff9b87cab19b020ce9414dcdeb17a4.0
  npm install @sberdevices/plasma-ui@1.63.1-canary.908.edee9289d5ff9b87cab19b020ce9414dcdeb17a4.0
  npm install @sberdevices/plasma-web@1.57.2-canary.908.edee9289d5ff9b87cab19b020ce9414dcdeb17a4.0
  npm install @sberdevices/plasma-sb-utils@0.34.2-canary.908.edee9289d5ff9b87cab19b020ce9414dcdeb17a4.0
  npm install @sberdevices/showcase@0.72.1-canary.908.edee9289d5ff9b87cab19b020ce9414dcdeb17a4.0
  npm install @sberdevices/plasma-ui-docs@0.19.1-canary.908.edee9289d5ff9b87cab19b020ce9414dcdeb17a4.0
  npm install @sberdevices/plasma-web-docs@0.11.2-canary.908.edee9289d5ff9b87cab19b020ce9414dcdeb17a4.0
  npm install @sberdevices/plasma-website@0.6.1-canary.908.edee9289d5ff9b87cab19b020ce9414dcdeb17a4.0
  # or 
  yarn add @sberdevices/demo-canvas-app@0.40.1-canary.908.edee9289d5ff9b87cab19b020ce9414dcdeb17a4.0
  yarn add @sberdevices/plasma-b2c@1.18.1-canary.908.edee9289d5ff9b87cab19b020ce9414dcdeb17a4.0
  yarn add @sberdevices/plasma-core@1.35.2-canary.908.edee9289d5ff9b87cab19b020ce9414dcdeb17a4.0
  yarn add @sberdevices/plasma-icons@1.51.2-canary.908.edee9289d5ff9b87cab19b020ce9414dcdeb17a4.0
  yarn add @sberdevices/plasma-ui@1.63.1-canary.908.edee9289d5ff9b87cab19b020ce9414dcdeb17a4.0
  yarn add @sberdevices/plasma-web@1.57.2-canary.908.edee9289d5ff9b87cab19b020ce9414dcdeb17a4.0
  yarn add @sberdevices/plasma-sb-utils@0.34.2-canary.908.edee9289d5ff9b87cab19b020ce9414dcdeb17a4.0
  yarn add @sberdevices/showcase@0.72.1-canary.908.edee9289d5ff9b87cab19b020ce9414dcdeb17a4.0
  yarn add @sberdevices/plasma-ui-docs@0.19.1-canary.908.edee9289d5ff9b87cab19b020ce9414dcdeb17a4.0
  yarn add @sberdevices/plasma-web-docs@0.11.2-canary.908.edee9289d5ff9b87cab19b020ce9414dcdeb17a4.0
  yarn add @sberdevices/plasma-website@0.6.1-canary.908.edee9289d5ff9b87cab19b020ce9414dcdeb17a4.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
