### PR TITLE
fix(plasma-web): prevent radiobox elipse shrinking

### DIFF
--- a/packages/plasma-web/src/components/Radiobox/Radiobox.tsx
+++ b/packages/plasma-web/src/components/Radiobox/Radiobox.tsx
@@ -13,6 +13,7 @@ import {
 export interface RadioboxProps extends BaseboxProps {}
 
 const StyledTrigger = styled(CheckboxTrigger)`
+    flex-shrink: 0;
     width: 1.25rem;
     height: 1.25rem;
     border-radius: 1.125rem;


### PR DESCRIPTION
Исправлено сужение радиокнопки

<img width="223" alt="изображение" src="https://user-images.githubusercontent.com/89986887/139879109-427f2b0e-b7d7-40cd-abed-79e9dd3f09df.png">
<img width="233" alt="изображение" src="https://user-images.githubusercontent.com/89986887/139879135-9a56b37f-6483-434a-a2e4-703ad3d9ccf1.png">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-b2c@1.16.3-canary.912.8274fd29d2aece8d920c09fad95cd39ae1de0055.0
  npm install @sberdevices/plasma-web@1.56.2-canary.912.8274fd29d2aece8d920c09fad95cd39ae1de0055.0
  npm install @sberdevices/showcase@0.69.4-canary.912.8274fd29d2aece8d920c09fad95cd39ae1de0055.0
  npm install @sberdevices/plasma-ui-docs@0.16.3-canary.912.8274fd29d2aece8d920c09fad95cd39ae1de0055.0
  npm install @sberdevices/plasma-web-docs@0.10.2-canary.912.8274fd29d2aece8d920c09fad95cd39ae1de0055.0
  npm install @sberdevices/plasma-website@0.4.2-canary.912.8274fd29d2aece8d920c09fad95cd39ae1de0055.0
  # or 
  yarn add @sberdevices/plasma-b2c@1.16.3-canary.912.8274fd29d2aece8d920c09fad95cd39ae1de0055.0
  yarn add @sberdevices/plasma-web@1.56.2-canary.912.8274fd29d2aece8d920c09fad95cd39ae1de0055.0
  yarn add @sberdevices/showcase@0.69.4-canary.912.8274fd29d2aece8d920c09fad95cd39ae1de0055.0
  yarn add @sberdevices/plasma-ui-docs@0.16.3-canary.912.8274fd29d2aece8d920c09fad95cd39ae1de0055.0
  yarn add @sberdevices/plasma-web-docs@0.10.2-canary.912.8274fd29d2aece8d920c09fad95cd39ae1de0055.0
  yarn add @sberdevices/plasma-website@0.4.2-canary.912.8274fd29d2aece8d920c09fad95cd39ae1de0055.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
