### PR TITLE
feat(plasma-ui): Added option to enable native input for Pickers

### DIFF
--- a/packages/plasma-ui/src/components/Pickers/DatePicker.tsx
+++ b/packages/plasma-ui/src/components/Pickers/DatePicker.tsx
@@ -67,6 +67,8 @@ export const DatePicker: React.FC<DatePickerProps> = ({
     visibleItems,
     scrollSnapType,
     onChange,
+    name,
+    enableNativeControl,
     ...rest
 }) => {
     const normalizeValues = React.useMemo(() => getNormalizeValues(getDateValues, getSeconds)(value, min, max), [
@@ -256,6 +258,7 @@ export const DatePicker: React.FC<DatePickerProps> = ({
                     onChange={onYearChange}
                 />
             )}
+            {enableNativeControl && <input type="hidden" value={value.toISOString()} name={name} />}
         </StyledWrapper>
     );
 };

--- a/packages/plasma-ui/src/components/Pickers/Picker.tsx
+++ b/packages/plasma-ui/src/components/Pickers/Picker.tsx
@@ -170,6 +170,15 @@ export interface PickerProps
      * Автофокус на компоненте.
      */
     autofocus?: boolean;
+    /**
+     * Добавляет нативный инпут для отправки в формах. Используется `input[type=hidden]`
+     */
+    enableNativeControl?: boolean;
+    /**
+     * Имя нативного инпута. Полезно при отправке uncontrolled-форм.
+     * Используется вместе с пропом `enableNativeControl`.
+     */
+    name?: string;
 }
 
 export const Picker: React.FC<PickerProps> = ({

--- a/packages/plasma-ui/src/components/Pickers/Pickers.stories.tsx
+++ b/packages/plasma-ui/src/components/Pickers/Pickers.stories.tsx
@@ -44,6 +44,8 @@ interface DefaultStoryProps extends DatePickerProps {
     TimePickerStep: number;
     DatePickerVisibleItems: number;
     TimePickerVisibleItems: number;
+    DatePickerNativeControl: boolean;
+    TimePickerNativeControl: boolean;
     optionsYears: boolean;
     optionsMonths: boolean;
     optionsDays: boolean;
@@ -98,6 +100,7 @@ export const Default: Story<DefaultStoryProps> = (args) => {
                 controls={args.controls}
                 autofocus={args.autofocus}
                 onChange={onChange}
+                enableNativeControl={args.DatePickerNativeControl}
             />
             <TimePicker
                 id="timepicker"
@@ -112,6 +115,7 @@ export const Default: Story<DefaultStoryProps> = (args) => {
                 disabled={args.disabled}
                 controls={args.controls}
                 onChange={onChange}
+                enableNativeControl={args.TimePickerNativeControl}
             />
         </StyledWrapper>
     );
@@ -137,6 +141,8 @@ Default.args = {
     TimePickeSize: 's',
     TimePickerStep: 1,
     TimePickerVisibleItems: 5,
+    DatePickerNativeControl: false,
+    TimePickerNativeControl: false,
 };
 
 Default.argTypes = {

--- a/packages/plasma-ui/src/components/Pickers/TimePicker.tsx
+++ b/packages/plasma-ui/src/components/Pickers/TimePicker.tsx
@@ -149,6 +149,8 @@ export const TimePicker: React.FC<TimePickerProps> = ({
     scrollSnapType,
     visibleItems,
     onChange,
+    name,
+    enableNativeControl,
     ...rest
 }) => {
     const normalizeValues = React.useMemo(() => getNormalizeValues(getTimeValues, getSeconds)(value, min, max), [
@@ -303,6 +305,7 @@ export const TimePicker: React.FC<TimePickerProps> = ({
                     onChange={onSecondsChange}
                 />
             )}
+            {enableNativeControl && <input type="hidden" value={value.toISOString()} name={name} />}
         </StyledWrapper>
     );
 };


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/demo-canvas-app@0.39.0-canary.916.2135eb39270b37488dc6dfe3a0db61d58a549dcc.0
  npm install @sberdevices/plasma-ui@1.62.0-canary.916.2135eb39270b37488dc6dfe3a0db61d58a549dcc.0
  npm install @sberdevices/showcase@0.71.0-canary.916.2135eb39270b37488dc6dfe3a0db61d58a549dcc.0
  npm install @sberdevices/plasma-ui-docs@0.18.0-canary.916.2135eb39270b37488dc6dfe3a0db61d58a549dcc.0
  # or 
  yarn add @sberdevices/demo-canvas-app@0.39.0-canary.916.2135eb39270b37488dc6dfe3a0db61d58a549dcc.0
  yarn add @sberdevices/plasma-ui@1.62.0-canary.916.2135eb39270b37488dc6dfe3a0db61d58a549dcc.0
  yarn add @sberdevices/showcase@0.71.0-canary.916.2135eb39270b37488dc6dfe3a0db61d58a549dcc.0
  yarn add @sberdevices/plasma-ui-docs@0.18.0-canary.916.2135eb39270b37488dc6dfe3a0db61d58a549dcc.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
