### PR TITLE
fix(plasma-b2c): reduce slider handle z-index

### DIFF
--- a/packages/plasma-b2c/src/components/Slider/Handle.tsx
+++ b/packages/plasma-b2c/src/components/Slider/Handle.tsx
@@ -19,7 +19,7 @@ interface HandleProps {
 
 const HandleStyled = styled.div`
     position: absolute;
-    z-index: 100;
+    z-index: 1;
     top: 0;
     left: 0;
 `;


### PR DESCRIPTION
Уменьшил zIndex у ручки слайдера, чтобы не просвечивал через модальные окна и прочие элементы, очень не удобно прописывать у всех элементов большие zIndex
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-b2c@1.19.2-canary.927.a05be15346f17ce57bbb6a43364b66d053dc423d.0
  npm install @sberdevices/showcase@0.73.2-canary.927.a05be15346f17ce57bbb6a43364b66d053dc423d.0
  npm install @sberdevices/plasma-website@0.8.2-canary.927.a05be15346f17ce57bbb6a43364b66d053dc423d.0
  # or 
  yarn add @sberdevices/plasma-b2c@1.19.2-canary.927.a05be15346f17ce57bbb6a43364b66d053dc423d.0
  yarn add @sberdevices/showcase@0.73.2-canary.927.a05be15346f17ce57bbb6a43364b66d053dc423d.0
  yarn add @sberdevices/plasma-website@0.8.2-canary.927.a05be15346f17ce57bbb6a43364b66d053dc423d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
