### PR TITLE
fix: plasma-web grid mobile margins

### DIFF
--- a/packages/plasma-web/src/utils/mediaQuery.ts
+++ b/packages/plasma-web/src/utils/mediaQuery.ts
@@ -12,7 +12,6 @@ export const columns = {
 export const margins = {
     XXL: 4,
     ...gridMargins,
-    S: 2,
     XL: 4,
 };
 export const gutters = {


### PR DESCRIPTION
Для мобилок боковые отступы должны быть 16пх
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-b2c@1.19.1-canary.928.c7afdb42c509c2ff2359d4e5321110da8e2d4337.0
  npm install @sberdevices/plasma-web@1.58.1-canary.928.c7afdb42c509c2ff2359d4e5321110da8e2d4337.0
  npm install @sberdevices/showcase@0.73.1-canary.928.c7afdb42c509c2ff2359d4e5321110da8e2d4337.0
  npm install @sberdevices/plasma-ui-docs@0.21.1-canary.928.c7afdb42c509c2ff2359d4e5321110da8e2d4337.0
  npm install @sberdevices/plasma-web-docs@0.13.1-canary.928.c7afdb42c509c2ff2359d4e5321110da8e2d4337.0
  npm install @sberdevices/plasma-website@0.8.1-canary.928.c7afdb42c509c2ff2359d4e5321110da8e2d4337.0
  # or 
  yarn add @sberdevices/plasma-b2c@1.19.1-canary.928.c7afdb42c509c2ff2359d4e5321110da8e2d4337.0
  yarn add @sberdevices/plasma-web@1.58.1-canary.928.c7afdb42c509c2ff2359d4e5321110da8e2d4337.0
  yarn add @sberdevices/showcase@0.73.1-canary.928.c7afdb42c509c2ff2359d4e5321110da8e2d4337.0
  yarn add @sberdevices/plasma-ui-docs@0.21.1-canary.928.c7afdb42c509c2ff2359d4e5321110da8e2d4337.0
  yarn add @sberdevices/plasma-web-docs@0.13.1-canary.928.c7afdb42c509c2ff2359d4e5321110da8e2d4337.0
  yarn add @sberdevices/plasma-website@0.8.1-canary.928.c7afdb42c509c2ff2359d4e5321110da8e2d4337.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
