### PR TITLE
feat(plasma-ui): Add a11y for `Stepper` component

### DIFF
--- a/packages/plasma-ui/src/components/Stepper/Stepper.stories.tsx
+++ b/packages/plasma-ui/src/components/Stepper/Stepper.stories.tsx
@@ -42,6 +42,7 @@ export const Default = () => {
             {items.map((item, i) => (
                 <ShowcaseComponentRow key={`item:${i}`}>
                     <Stepper
+                        aria-label={`Счётчик ${i + 1}`}
                         step={1}
                         value={values[i]}
                         min={item.min}
@@ -55,6 +56,9 @@ export const Default = () => {
                         onRemove={onRemoveAction}
                         onFocus={onFocusAction}
                         onBlur={onBlurAction}
+                        ariaLabelRemove="Удалить"
+                        ariaLabelDecrement="Уменьшить значение"
+                        ariaLabelIncrement="Увеличить значение"
                     />
                 </ShowcaseComponentRow>
             ))}
@@ -75,8 +79,9 @@ export const CustomAssembly: Story<CustomAssemblyProps> = ({ step, min, max, dis
     const [value, setValue] = useState(5);
     const formatter = (val: number) => `${val}$`;
     return (
-        <StepperRoot>
+        <StepperRoot aria-label="Счётчик">
             <StepperButton
+                aria-label="Уменьшить значение"
                 view={value > min ? 'secondary' : 'critical'}
                 icon={value > min ? <IconMinus color="inherit" size="xs" /> : <IconClose color="inherit" size="xs" />}
                 onClick={() => setValue(Math.max(value - step, min))}
@@ -88,6 +93,7 @@ export const CustomAssembly: Story<CustomAssemblyProps> = ({ step, min, max, dis
                 formatter={showFormat && formatter}
             />
             <StepperButton
+                aria-label="Увеличить значение"
                 view="secondary"
                 icon={<IconPlus color="inherit" size="xs" />}
                 disabled={value >= max}

--- a/packages/plasma-ui/src/components/Stepper/Stepper.tsx
+++ b/packages/plasma-ui/src/components/Stepper/Stepper.tsx
@@ -51,6 +51,18 @@ export type StepperProps = (RemoverProps | NoRemoverProps) &
          * Функция для форматирования отображаемого значения
          */
         formatter?: (value: number) => string;
+        /**
+         * ARIA атрибут для кнопки увеличения значения
+         */
+        ariaLabelIncrement?: string;
+        /**
+         * ARIA атрибут для кнопки удаления
+         */
+        ariaLabelRemove?: string;
+        /**
+         * ARIA атрибут для кнопки уменьшения значения
+         */
+        ariaLabelDecrement?: string;
     };
 
 /**
@@ -67,6 +79,9 @@ export const Stepper: React.FC<StepperProps> = ({
     onFocus,
     onBlur,
     formatter,
+    ariaLabelDecrement,
+    ariaLabelIncrement,
+    ariaLabelRemove,
     ...props
 }) => {
     const { showRemove: remover, onRemove, ...rest } = props as RemoverProps;
@@ -81,6 +96,7 @@ export const Stepper: React.FC<StepperProps> = ({
     return (
         <StepperRoot {...rest}>
             <StepperButton
+                aria-label={isMin && remover ? ariaLabelRemove : ariaLabelDecrement}
                 disabled={disabled || (!remover && lessDisabled)}
                 icon={
                     isMin && remover ? <IconClose color="inherit" size="xs" /> : <IconMinus color="inherit" size="xs" />
@@ -93,6 +109,7 @@ export const Stepper: React.FC<StepperProps> = ({
             />
             <StepperValue value={value} disabled={disabled} showWarning={isMax} formatter={formatter} />
             <StepperButton
+                aria-label={ariaLabelIncrement}
                 disabled={disabled || moreDisabled}
                 icon={<IconPlus color="inherit" size="xs" />}
                 pin={pin}

--- a/packages/plasma-ui/src/components/Stepper/StepperButton.tsx
+++ b/packages/plasma-ui/src/components/Stepper/StepperButton.tsx
@@ -15,9 +15,17 @@ export interface StepperButtonProps
  */
 export const StepperButton = React.forwardRef<HTMLButtonElement, StepperButtonProps>(
     // eslint-disable-next-line prefer-arrow-callback
-    function StepperButton({ pin = 'circle-circle', view = 'secondary', icon, ...rest }, ref) {
+    function StepperButton({ pin = 'circle-circle', view = 'secondary', icon, disabled, ...rest }, ref) {
         return (
-            <ActionButton size="m" ref={ref} pin={pin} view={view} {...rest}>
+            <ActionButton
+                aria-disabled={disabled}
+                disabled={disabled}
+                size="m"
+                ref={ref}
+                pin={pin}
+                view={view}
+                {...rest}
+            >
                 {icon}
             </ActionButton>
         );

--- a/packages/plasma-ui/src/components/Stepper/StepperValue.tsx
+++ b/packages/plasma-ui/src/components/Stepper/StepperValue.tsx
@@ -57,7 +57,7 @@ export interface StepperValueProps extends React.HTMLAttributes<HTMLDivElement>,
  * Компонент для отображения значения степпера.
  */
 export const StepperValue: React.FC<StepperValueProps> = ({ value, disabled, showWarning, formatter, ...rest }) => (
-    <StyledValue disabled={disabled} showWarning={showWarning} {...rest}>
+    <StyledValue role="status" aria-live="polite" disabled={disabled} showWarning={showWarning} {...rest}>
         {typeof formatter === 'function' ? formatter(value) : value}
     </StyledValue>
 );

--- a/website/plasma-ui-docs/docs/components/Stepper.mdx
+++ b/website/plasma-ui-docs/docs/components/Stepper.mdx
@@ -12,6 +12,10 @@ import { PropsTable, Description } from '@site/src/components';
 <Description name="Stepper" />
 <PropsTable name="Stepper" />
 
+### Доступность
+
+Для добавления доступности по стандарту ARIA, необходимо указать значения пропсов `ariaLabelDecrement`, `ariaLabelRemove`, `ariaLabelIncrement`, которые попадут в соотвествующие **aria-label** атрибуты для кнопок уменьшения, удаления и добавления значения.
+
 ### Пример
 
 ```tsx live
@@ -33,6 +37,8 @@ export function App() {
             onRemove={() => console.log('onRemove')}
             onFocus={() => console.log('onFocus')}
             onBlur={() => console.log('onBlur')}
+            ariaLabelDecrement="Уменьшить значение"
+            ariaLabelIncrement="Увеличить значение"
         />
     );
 }
@@ -59,6 +65,10 @@ export function App() {
 <Description name="StepperValue" />
 <PropsTable name="StepperValue" />
 
+### Доступность
+
+Для добавления доступности по стандарту ARIA, необходимо указать атрибуты **aria-label** для кнопок уменьшения, удаления и добавления значения. 
+
 ### Пример
 ```tsx live
 import React, { useState } from 'react';
@@ -74,12 +84,14 @@ export function App() {
     return (
         <StepperRoot>
             <StepperButton
+                aria-label="Уменьшить значение"
                 view={value > min ? 'secondary' : 'critical'}
                 icon={value > min ? <IconMinus color="inherit" size="xs" /> : <IconClose color="inherit" size="xs" />}
                 onClick={() => setValue(Math.max(value - step, min))}
             />
             <StepperValue value={value} disabled={false} showWarning={false} />
             <StepperButton
+                aria-label="Увеличить значение"
                 view="secondary"
                 icon={<IconPlus color="inherit" size="xs" />}
                 disabled={value >= max}

--- a/website/plasma-ui-docs/docs/components/Stepper.mdx
+++ b/website/plasma-ui-docs/docs/components/Stepper.mdx
@@ -37,6 +37,7 @@ export function App() {
             onRemove={() => console.log('onRemove')}
             onFocus={() => console.log('onFocus')}
             onBlur={() => console.log('onBlur')}
+            ariaLabelRemove="Удалить"
             ariaLabelDecrement="Уменьшить значение"
             ariaLabelIncrement="Увеличить значение"
         />


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/demo-canvas-app@0.45.0-canary.930.0878aab7d00d478b63ec1f317c600563808c0d93.0
  npm install @sberdevices/plasma-ui@1.68.0-canary.930.0878aab7d00d478b63ec1f317c600563808c0d93.0
  npm install @sberdevices/showcase@0.77.0-canary.930.0878aab7d00d478b63ec1f317c600563808c0d93.0
  npm install @sberdevices/plasma-ui-docs@0.27.0-canary.930.0878aab7d00d478b63ec1f317c600563808c0d93.0
  # or 
  yarn add @sberdevices/demo-canvas-app@0.45.0-canary.930.0878aab7d00d478b63ec1f317c600563808c0d93.0
  yarn add @sberdevices/plasma-ui@1.68.0-canary.930.0878aab7d00d478b63ec1f317c600563808c0d93.0
  yarn add @sberdevices/showcase@0.77.0-canary.930.0878aab7d00d478b63ec1f317c600563808c0d93.0
  yarn add @sberdevices/plasma-ui-docs@0.27.0-canary.930.0878aab7d00d478b63ec1f317c600563808c0d93.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
