### PR TITLE
feat(website): add description for templates docs

### DIFF
--- a/website/plasma-temple-docs/docs/templates.md
+++ b/website/plasma-temple-docs/docs/templates.md
@@ -6,31 +6,94 @@ sidebar_position: 4
 
 # Шаблоны
 
-## Шаблоны для использования в смартапе
+## Шаблоны Контента
 
-### Шаблоны Контента
+### [`GalleryPage`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/pages/GalleryPage/GalleryPage.tsx)
 
--   [`GalleryPage`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/pages/GalleryPage/GalleryPage.tsx) ([example 1](https://codesandbox.io/s/simple-gallery-page-flfwj) / [example 2](https://codesandbox.io/s/multiple-gallery-vfrig) / [example 3](https://codesandbox.io/s/gallery-custom-card-my0zr))
--   [`GridPage`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/pages/GridPage/GridPage.tsx) ([example](https://codesandbox.io/s/grid-page-bje3t))
--   [`ItemPage`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/pages/ItemPage/ItemPage.tsx) ([example](https://codesandbox.io/s/item-page-d0vcd))
--   [`VideoPage`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/pages/VideoPage/VideoPage.tsx)
+[example 1](https://codesandbox.io/s/simple-gallery-page-flfwj) / [example 2](https://codesandbox.io/s/multiple-gallery-vfrig) / [example 3](https://codesandbox.io/s/gallery-custom-card-my0zr)
 
-### Шаблон ошибки
+Экран для отображения каталога на базе каруселей
 
--   [`ErrorPage`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/pages/ErrorPage) ([example](https://codesandbox.io/s/error-screen-example-4zf9s))
+### [`GridPage`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/pages/GridPage/GridPage.tsx)
 
-### Специализированные шаблоны
+[example](https://codesandbox.io/s/grid-page-bje3t)
 
--   [`ShopLangingPage`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/pages/ShopLandingPage) ([example](https://codesandbox.io/s/shop-main-page-7e5sq))
--   [`CartPage`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/pages/CartPage) ([example](https://codesandbox.io/s/cart-page-example-9z0dx))
--   [`OrderSuccessPage`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/pages/OrderSuccessPage) ([example](https://codesandbox.io/s/order-confirm-success-pages-qyiw0))
--   [`ConfirmOrderPage`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/pages/ConfirmOrderPage) ([example](https://codesandbox.io/s/order-confirm-success-pages-qyiw0))
+Экран для списка элементов в виде сетки с вертикальным скроллом
 
-### Компоненты
+### [`ItemPage`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/pages/ItemPage/ItemPage.tsx)
 
--   [`Form`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/components/Form) ([example](https://codesandbox.io/s/form-example-qvupj))
--   [`HeroSlider`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/components/HeroSlider) ([example](https://codesandbox.io/s/teaser-page-9sd4w))
--   [`StateLayout`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/components/StateLayout) ([example](https://codesandbox.io/s/error-screen-example-4zf9s))
--   [`Product`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/components/Product) ([example](https://codesandbox.io/s/product-page-example-me5h4))
--   [`MediaPlayer`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/components/MediaPlayer)
--   [`VideoPlayer`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/components/VideoPlayer)
+[example](https://codesandbox.io/s/item-page-d0vcd)
+
+Экран для детального отобжения контента
+
+### [`VideoPage`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/pages/VideoPage/VideoPage.tsx)
+
+Экран для показа видео контета
+
+## Шаблон ошибки
+
+### [`ErrorPage`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/pages/ErrorPage)
+
+[example](https://codesandbox.io/s/error-screen-example-4zf9s)
+
+Экран для отображения ошибки
+
+## Специализированные шаблоны
+
+### [`ShopLangingPage`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/pages/ShopLandingPage)
+
+[example](https://codesandbox.io/s/shop-main-page-7e5sq)
+
+Разводящий экран для e-com навыков
+
+### [`CartPage`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/pages/CartPage)
+
+[example](https://codesandbox.io/s/cart-page-example-9z0dx)
+
+Экран корзины для e-com навыков
+
+### [`OrderSuccessPage`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/pages/OrderSuccessPage)
+
+[example](https://codesandbox.io/s/order-confirm-success-pages-qyiw0)
+
+Экран об успешном оформлении заказа для e-com навыков
+
+### [`ConfirmOrderPage`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/pages/ConfirmOrderPage)
+
+[example](https://codesandbox.io/s/order-confirm-success-pages-qyiw0)
+
+Экран подтверждения заказа для e-com навыков
+
+## Компоненты
+
+### [`Form`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/components/Form)
+
+[example](https://codesandbox.io/s/form-example-qvupj)
+
+Компонент для построения форм ввода разлиных данных пользователем
+
+### [`HeroSlider`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/components/HeroSlider)
+
+[example](https://codesandbox.io/s/teaser-page-9sd4w)
+
+Компонент для представления важного конента
+
+### [`StateLayout`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/components/StateLayout)
+
+[example](https://codesandbox.io/s/error-screen-example-4zf9s)
+
+Компонент для формирования состояния, например пройденного этапа или созданного заказа
+
+### [`Product`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/components/Product)
+
+[example](https://codesandbox.io/s/product-page-example-me5h4)
+
+Набор компонент для построения экрана деталоного описания товара или услуги для e-com навыков
+
+### [`MediaPlayer`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/components/MediaPlayer)
+
+Набор компонент для построения аудио- или видеоплеера
+
+### [`VideoPlayer`](https://github.com/sberdevices/plasma/blob/master/packages/plasma-temple/src/components/VideoPlayer)
+
+Готовый компонент видеоплеера


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-b2c@1.20.0-canary.931.4e8074102b7a63849e2fb7d8458b205d31ff54ae.0
  npm install @sberdevices/showcase@0.74.0-canary.931.4e8074102b7a63849e2fb7d8458b205d31ff54ae.0
  npm install @sberdevices/plasma-website@0.9.0-canary.931.4e8074102b7a63849e2fb7d8458b205d31ff54ae.0
  # or 
  yarn add @sberdevices/plasma-b2c@1.20.0-canary.931.4e8074102b7a63849e2fb7d8458b205d31ff54ae.0
  yarn add @sberdevices/showcase@0.74.0-canary.931.4e8074102b7a63849e2fb7d8458b205d31ff54ae.0
  yarn add @sberdevices/plasma-website@0.9.0-canary.931.4e8074102b7a63849e2fb7d8458b205d31ff54ae.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
