### PR TITLE
fix(plama-web): Added possibility to specify a value type in `Select`

### DIFF
--- a/packages/plasma-web/src/components/Select/Select.tsx
+++ b/packages/plasma-web/src/components/Select/Select.tsx
@@ -1,37 +1,41 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, ReactElement, RefAttributes } from 'react';
 
 import { SelectView } from './SelectView';
-import { withSingleSelect, SingleSelectProps } from './withSingleSelect';
-import { withMultiSelect, MultiSelectProps } from './withMultiSelect';
+import { withSingleSelect } from './withSingleSelect';
+import { withMultiSelect } from './withMultiSelect';
 import type { SelectViewProps, SelectRefElement } from './Select.types';
 
-export type SelectProps = Omit<SelectViewProps, 'label'> &
-    (
-        | {
-              /**
-               * Выбор нескольких значений.
-               */
-              multiselect?: false;
-              /**
-               * Значение компонента.
-               */
-              value: SingleSelectProps['value'];
-              /**
-               * Разделитель выбранных значений.
-               */
-              separator?: never;
-              /**
-               * Обработчик изменения значения.
-               */
-              onChange?: SingleSelectProps['onChange'];
-          }
-        | {
-              multiselect: true;
-              value: MultiSelectProps['value'];
-              separator?: string;
-              onChange?: MultiSelectProps['onChange'];
-          }
-    );
+export type SelectProps<T = any> = (
+    | {
+          /**
+           * Выбор нескольких значений.
+           */
+          multiselect?: false;
+          /**
+           * Разделитель выбранных значений.
+           */
+          separator?: never;
+      }
+    | {
+          /**
+           * Выбор нескольких значений.
+           */
+          multiselect?: true;
+          /**
+           * Разделитель выбранных значений.
+           */
+          separator?: string;
+      }
+) & {
+    /**
+     * Значение контрола.
+     */
+    value: T;
+    /**
+     * Обработчик изменения значения.
+     */
+    onChange?: (value: T) => void;
+} & Omit<SelectViewProps, 'onItemClick' | 'value' | 'label' | 'multiselect'>;
 
 const SingleSelect = withSingleSelect(SelectView);
 const MultiSelect = withMultiSelect(SelectView);
@@ -40,9 +44,10 @@ const MultiSelect = withMultiSelect(SelectView);
  * Выпадающий список для использования в формах.
  * Поддерживает выбор одного или нескольких значений.
  */
-export const Select = forwardRef<SelectRefElement, SelectProps>((props, ref) => {
+// eslint-disable-next-line prefer-arrow-callback
+export const Select = forwardRef<SelectRefElement, SelectProps>(function Select(props, ref) {
     if (props.multiselect) {
         return <MultiSelect ref={ref} {...props} />;
     }
     return <SingleSelect ref={ref} {...props} />;
-});
+}) as <T>(props: SelectProps<T> & RefAttributes<SelectRefElement>) => ReactElement;

--- a/packages/plasma-web/src/components/Select/withMultiSelect.tsx
+++ b/packages/plasma-web/src/components/Select/withMultiSelect.tsx
@@ -4,10 +4,19 @@ import type { ComponentType, RefAttributes } from 'react';
 import { flattenItemsRecursive, setActiveRecursive } from './Select.utils';
 import type { SelectRefElement, SelectViewProps } from './Select.types';
 
-export interface MultiSelectProps extends Omit<SelectViewProps, 'onItemClick' | 'value' | 'label'> {
+export interface MultiSelectProps extends Omit<SelectViewProps, 'onItemClick' | 'value' | 'label' | 'multiselect'> {
+    /**
+     * Значение контрола.
+     */
     value: Array<string | number> | null;
+    /**
+     * Разделитель выбранных значений.
+     */
     separator?: string;
-    onChange?: (value: Array<string | number>) => void;
+    /**
+     * Обработчик изменения значения.
+     */
+    onChange?: (value: Array<string | number> | null) => void;
 }
 
 /**

--- a/packages/plasma-web/src/components/Select/withSingleSelect.tsx
+++ b/packages/plasma-web/src/components/Select/withSingleSelect.tsx
@@ -4,8 +4,15 @@ import type { ComponentType, RefAttributes } from 'react';
 import { flattenItemsRecursive, setActiveRecursive } from './Select.utils';
 import type { SelectRefElement, SelectViewProps } from './Select.types';
 
-export interface SingleSelectProps extends Omit<SelectViewProps, 'onItemClick' | 'label'> {
-    onChange?: (value: string | number) => void;
+export interface SingleSelectProps extends Omit<SelectViewProps, 'onItemClick' | 'value' | 'label' | 'multiselect'> {
+    /**
+     * Значение контрола.
+     */
+    value: string | number | null;
+    /**
+     * Обработчик изменения значения.
+     */
+    onChange?: (value: string | number | null) => void;
 }
 
 /**


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-b2c@1.26.1-canary.932.54c682715e524eb929a8d6a426f9542d4e8564b0.0
  npm install @sberdevices/plasma-web@1.64.1-canary.932.54c682715e524eb929a8d6a426f9542d4e8564b0.0
  npm install @sberdevices/showcase@0.81.1-canary.932.54c682715e524eb929a8d6a426f9542d4e8564b0.0
  npm install @sberdevices/plasma-ui-docs@0.30.1-canary.932.54c682715e524eb929a8d6a426f9542d4e8564b0.0
  npm install @sberdevices/plasma-web-docs@0.21.1-canary.932.54c682715e524eb929a8d6a426f9542d4e8564b0.0
  npm install @sberdevices/plasma-website@0.15.1-canary.932.54c682715e524eb929a8d6a426f9542d4e8564b0.0
  # or 
  yarn add @sberdevices/plasma-b2c@1.26.1-canary.932.54c682715e524eb929a8d6a426f9542d4e8564b0.0
  yarn add @sberdevices/plasma-web@1.64.1-canary.932.54c682715e524eb929a8d6a426f9542d4e8564b0.0
  yarn add @sberdevices/showcase@0.81.1-canary.932.54c682715e524eb929a8d6a426f9542d4e8564b0.0
  yarn add @sberdevices/plasma-ui-docs@0.30.1-canary.932.54c682715e524eb929a8d6a426f9542d4e8564b0.0
  yarn add @sberdevices/plasma-web-docs@0.21.1-canary.932.54c682715e524eb929a8d6a426f9542d4e8564b0.0
  yarn add @sberdevices/plasma-website@0.15.1-canary.932.54c682715e524eb929a8d6a426f9542d4e8564b0.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
