### PR TITLE
fix(plasma-web): Add `Button`'s `warning` view

### DIFF
--- a/packages/plasma-web/src/components/Button/Button.stories.tsx
+++ b/packages/plasma-web/src/components/Button/Button.stories.tsx
@@ -6,7 +6,7 @@ import { IconPlaceholder, disableProps } from '../../helpers';
 
 import { Button, ButtonProps } from '.';
 
-const views = ['primary', 'secondary', 'success', 'critical'];
+const views = ['primary', 'secondary', 'success', 'warning', 'critical', 'clear'];
 const sizes = ['l', 'm', 's'];
 const pins = [
     'square-square',

--- a/packages/plasma-web/src/components/Button/Button.tsx
+++ b/packages/plasma-web/src/components/Button/Button.tsx
@@ -59,6 +59,14 @@ const buttonViews = {
             color: ${baseViews.success.color};
         }
     `,
+    warning: css`
+        ${baseViews.warning}
+        ${viewInteractive}
+
+        &:hover {
+            color: ${baseViews.warning.color};
+        }
+    `,
     critical: css`
         ${baseViews.critical}
         ${viewInteractive}


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-b2c@1.20.2-canary.933.904de84dc8edbb263491e61079e0bf5eadddef34.0
  npm install @sberdevices/plasma-web@1.59.2-canary.933.904de84dc8edbb263491e61079e0bf5eadddef34.0
  npm install @sberdevices/showcase@0.74.2-canary.933.904de84dc8edbb263491e61079e0bf5eadddef34.0
  npm install @sberdevices/plasma-ui-docs@0.24.1-canary.933.904de84dc8edbb263491e61079e0bf5eadddef34.0
  npm install @sberdevices/plasma-web-docs@0.16.1-canary.933.904de84dc8edbb263491e61079e0bf5eadddef34.0
  npm install @sberdevices/plasma-website@0.9.2-canary.933.904de84dc8edbb263491e61079e0bf5eadddef34.0
  # or 
  yarn add @sberdevices/plasma-b2c@1.20.2-canary.933.904de84dc8edbb263491e61079e0bf5eadddef34.0
  yarn add @sberdevices/plasma-web@1.59.2-canary.933.904de84dc8edbb263491e61079e0bf5eadddef34.0
  yarn add @sberdevices/showcase@0.74.2-canary.933.904de84dc8edbb263491e61079e0bf5eadddef34.0
  yarn add @sberdevices/plasma-ui-docs@0.24.1-canary.933.904de84dc8edbb263491e61079e0bf5eadddef34.0
  yarn add @sberdevices/plasma-web-docs@0.16.1-canary.933.904de84dc8edbb263491e61079e0bf5eadddef34.0
  yarn add @sberdevices/plasma-website@0.9.2-canary.933.904de84dc8edbb263491e61079e0bf5eadddef34.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
