### PR TITLE
feat(plasma-temple):  Additional buttons in ItemPage

### DIFF
--- a/packages/plasma-temple/src/pages/ItemPage/ItemPage.tsx
+++ b/packages/plasma-temple/src/pages/ItemPage/ItemPage.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { HeaderProps } from '@sberdevices/plasma-ui/components/Header/Header';
+import { ButtonProps } from '@sberdevices/plasma-ui';
 
 import { Header } from '../../components/Header/Header';
 import { useRegistry } from '../../hooks/useRegistry';
@@ -18,6 +19,7 @@ interface ItemPageProps {
     onItemShow: <T>(id: T) => void;
     onItemFocus?: <T>(id: T) => void;
     entityComponent?: React.ComponentType<ItemEntityProps>;
+    additionalButons?: ButtonProps[];
 }
 
 const scrollToWithOffset = (offset: number, element: HTMLDivElement | null) => {
@@ -35,7 +37,14 @@ const scrollToWithOffset = (offset: number, element: HTMLDivElement | null) => {
     });
 };
 
-export const ItemPage: React.FC<ItemPageProps> = ({ state, header, entityComponent, onItemShow, onItemFocus }) => {
+export const ItemPage: React.FC<ItemPageProps> = ({
+    state,
+    header,
+    entityComponent,
+    onItemShow,
+    onItemFocus,
+    additionalButons,
+}) => {
     const { entities, entitiesTitle, background, title, subtitle, description, actionButtonText } = state;
     const { ItemMainSection, ItemEntities } = useRegistry();
     const layoutElementContext = React.useContext(LayoutElementContext);
@@ -77,6 +86,7 @@ export const ItemPage: React.FC<ItemPageProps> = ({ state, header, entityCompone
                 description={description}
                 onItemShow={() => onItemShow(entities[0].id)}
                 itemShowButtonText={actionButtonText}
+                additionalButons={additionalButons}
             />
             <ItemEntities list={list} title={entitiesTitle ?? ''} Component={entityComponent} />
         </>

--- a/packages/plasma-temple/src/pages/ItemPage/components/ItemMainSection/ItemMainSection.tsx
+++ b/packages/plasma-temple/src/pages/ItemPage/components/ItemMainSection/ItemMainSection.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Cell, TextBox, TextBoxLabel, TextBoxTitle, Button } from '@sberdevices/plasma-ui';
+import { Cell, TextBox, TextBoxLabel, TextBoxTitle, Button, ButtonProps } from '@sberdevices/plasma-ui';
 import { IconPlay } from '@sberdevices/plasma-icons/Icons/IconPlay';
 
 import { isSberBoxLike } from '../../../../utils/deviceFamily';
@@ -20,6 +20,7 @@ export interface ItemMainSectionProps {
     description?: ItemCellProps[];
     itemShowButtonText: string;
     onItemShow: () => void;
+    additionalButons?: ButtonProps[];
 }
 
 const StyledRow = styled.div`
@@ -63,12 +64,17 @@ export const ItemMainSection: React.FC<UnifiedComponentProps<ItemMainSectionProp
     onItemShow,
     cover,
     platformComponents: { Container, Title, Subtitle },
+    additionalButons = [],
 }) => {
     const buttonRef = React.useRef<HTMLButtonElement>(null);
 
     useFocusOnMount<HTMLButtonElement>(buttonRef, {
         delay: 250,
     });
+
+    const renderButton = (props: ButtonProps, index: number) => (
+        <Button key={`ItemMainSection-Button-${index}`} {...props} />
+    );
 
     return (
         <Container withSpatNav>
@@ -93,6 +99,7 @@ export const ItemMainSection: React.FC<UnifiedComponentProps<ItemMainSectionProp
                 outlined={isSberBoxLike()}
                 text={itemShowButtonText}
             />
+            {additionalButons.map(renderButton)}
         </Container>
     );
 };


### PR DESCRIPTION
Возможность добавить, помимо одной стандартной кнопки, дополнительные кнопки в ItemPage.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-temple@1.8.0-canary.938.4a8e0e66c28363ac370221d954157781f4a5368f.0
  # or 
  yarn add @sberdevices/plasma-temple@1.8.0-canary.938.4a8e0e66c28363ac370221d954157781f4a5368f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
