### PR TITLE
feat(plasma-temple): Don't use assistant dev mode  with Cypress

### DIFF
--- a/packages/plasma-temple/src/assistant.ts
+++ b/packages/plasma-temple/src/assistant.ts
@@ -25,7 +25,7 @@ export const initializeAssistant = <T extends AssistantSmartAppData>({
     userChannel = 'B2C',
     surface = 'SBERBOX',
 }: InitializeParams): AssistantInstance => {
-    if (process.env.NODE_ENV === 'development') {
+    if (process.env.NODE_ENV === 'development' && !window.Cypress) {
         const environmentProps = token
             ? {
                   userChannel: 'B2C',


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-temple@1.5.0-canary.940.0a7687b6e7a87d13636941116d031fe55d20d5ed.0
  # or 
  yarn add @sberdevices/plasma-temple@1.5.0-canary.940.0a7687b6e7a87d13636941116d031fe55d20d5ed.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
