### PR TITLE
feat(plasma-temple): support for window.appInitialData

### DIFF
--- a/packages/plasma-temple/src/utils/getAssistantSmartAppInitialData.ts
+++ b/packages/plasma-temple/src/utils/getAssistantSmartAppInitialData.ts
@@ -1,0 +1,23 @@
+import { AssistantClientCustomizedCommand, AssistantSmartAppData } from '@sberdevices/assistant-client';
+
+import { getAssistant } from '../assistant';
+
+export function getAssistantSmartAppInitialData<
+    T extends AssistantSmartAppData = AssistantSmartAppData
+>(): T['smart_app_data'][] {
+    const getSmartAppData = (command: AssistantClientCustomizedCommand<T>): T['smart_app_data'] | null => {
+        if (command.type === 'smart_app_data') {
+            return command.smart_app_data;
+        }
+        return null;
+    };
+
+    const initialData = getAssistant().getInitialData();
+    return initialData
+        .map(
+            getSmartAppData as (
+                command: AssistantClientCustomizedCommand<AssistantSmartAppData>,
+            ) => T['smart_app_data'],
+        )
+        .filter(Boolean);
+}

--- a/packages/plasma-temple/src/utils/index.ts
+++ b/packages/plasma-temple/src/utils/index.ts
@@ -1,2 +1,3 @@
 export { getMediaObjectSrc } from './getMediaObjectSrc';
 export { isSberBoxLike } from './deviceFamily';
+export { getAssistantSmartAppInitialData } from './getAssistantSmartAppInitialData';


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-temple@1.7.0-canary.941.11ba7dcb6bdeec8447d73594653870372d840a67.0
  # or 
  yarn add @sberdevices/plasma-temple@1.7.0-canary.941.11ba7dcb6bdeec8447d73594653870372d840a67.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
