### PR TITLE
feat: b2c button rounding

### DIFF
--- a/packages/plasma-b2c/src/components/Button/Button.tsx
+++ b/packages/plasma-b2c/src/components/Button/Button.tsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+import { convertRoundnessMatrix } from '@sberdevices/plasma-core';
+import { Button as BaseButton, ButtonProps } from '@sberdevices/plasma-web';
+
+/**
+ * Кнопка.
+ * Поддерживает текстовое и контентное наполнение.
+ */
+export const Button = styled(BaseButton)<ButtonProps>`
+    border-radius: ${({ pin }: ButtonProps) => convertRoundnessMatrix(pin, '0.75rem', '1.75rem')};
+`;

--- a/packages/plasma-b2c/src/components/Button/index.tsx
+++ b/packages/plasma-b2c/src/components/Button/index.tsx
@@ -1,2 +1,2 @@
-export { Button } from '@sberdevices/plasma-web';
+export { Button } from './Button';
 export type { ButtonProps } from '@sberdevices/plasma-web';


### PR DESCRIPTION
Для b2c для всех размеров кнопки должно быть скругление 12пх для типа square
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-b2c@1.23.0-canary.951.8ef6a05de920e6fcb07855c2e4ec37d7846dd8ac.0
  npm install @sberdevices/showcase@0.77.0-canary.951.8ef6a05de920e6fcb07855c2e4ec37d7846dd8ac.0
  npm install @sberdevices/plasma-website@0.12.0-canary.951.8ef6a05de920e6fcb07855c2e4ec37d7846dd8ac.0
  # or 
  yarn add @sberdevices/plasma-b2c@1.23.0-canary.951.8ef6a05de920e6fcb07855c2e4ec37d7846dd8ac.0
  yarn add @sberdevices/showcase@0.77.0-canary.951.8ef6a05de920e6fcb07855c2e4ec37d7846dd8ac.0
  yarn add @sberdevices/plasma-website@0.12.0-canary.951.8ef6a05de920e6fcb07855c2e4ec37d7846dd8ac.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
