### PR TITLE
feat: b2c put preview gallery rest props

### DIFF
--- a/packages/plasma-b2c/src/components/PreviewGallery/PreviewGallery.tsx
+++ b/packages/plasma-b2c/src/components/PreviewGallery/PreviewGallery.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import type { FC, HTMLAttributes } from 'react';
+import { SortableContainerProps, SortableElementProps } from 'react-sortable-hoc';
 
 import { noop } from './utils';
 import { PreviewGalleryListItems } from './PreviewGalleryItems';
@@ -15,7 +16,7 @@ export interface PreviewGalleryProps {
     /**
      * Массив элементов.
      */
-    items?: Array<PreviewGalleryItemProps>;
+    items?: Array<PreviewGalleryItemProps & SortableElementProps>;
     /**
      * Тип взаимодействия с галереей - выбор или перетаскивание элементов.
      */
@@ -49,7 +50,7 @@ export interface PreviewGalleryProps {
 /**
  * Компонент для создания галлереи превью изображений.
  */
-export const PreviewGallery: FC<PreviewGalleryProps & HTMLAttributes<HTMLDivElement>> = ({
+export const PreviewGallery: FC<PreviewGalleryProps & HTMLAttributes<HTMLDivElement> & SortableContainerProps> = ({
     interactionType = 'selectable',
     items = [],
     maxHeight = 0,

--- a/packages/plasma-b2c/src/components/PreviewGallery/PreviewGalleryItems.tsx
+++ b/packages/plasma-b2c/src/components/PreviewGallery/PreviewGalleryItems.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useMemo } from 'react';
-import { SortableContainer, SortableElement } from 'react-sortable-hoc';
+import { SortableContainer, SortableElement, SortableElementProps } from 'react-sortable-hoc';
 import styled, { css } from 'styled-components';
 
 import { AddionalItemProps } from './types';
@@ -28,7 +28,7 @@ export const StyledRoot = styled.div<{ isGrabbing: boolean; maxHeight?: number }
 `;
 
 export interface PreviewGalleryListItemsProps {
-    items?: Array<PreviewGalleryItemProps>;
+    items?: Array<PreviewGalleryItemProps & SortableElementProps>;
     /**
      * Перетаскивается ли элемент.
      */
@@ -52,6 +52,7 @@ export const PreviewGalleryListItems = SortableContainer(
         maxHeight,
         onItemAction,
         onItemClick,
+        ...rest
     }: PreviewGalleryListItemsProps & AddionalItemProps) => {
         const isDragDisabled = interactionType === 'selectable';
 
@@ -60,24 +61,24 @@ export const PreviewGalleryListItems = SortableContainer(
         const iconMemo = useMemo(() => actionIcon, []);
 
         const PreviewGalleryItem = memo(
-            SortableElement(({ status, ...rest }: PreviewGalleryItemProps & AddionalItemProps) => {
+            SortableElement(({ status, ...itemRest }: PreviewGalleryItemProps & AddionalItemProps) => {
                 return status === 'error' ? (
-                    <PreviewGalleryItemError {...rest} />
+                    <PreviewGalleryItemError {...itemRest} />
                 ) : (
-                    <PreviewGalleryItemBase {...rest} />
+                    <PreviewGalleryItemBase {...itemRest} />
                 );
             }),
         );
 
         return (
-            <StyledRoot isGrabbing={isGrabbing} maxHeight={maxHeight}>
+            <StyledRoot isGrabbing={isGrabbing} maxHeight={maxHeight} {...rest}>
                 {items.map((item, index) => (
                     <PreviewGalleryItem
                         disabled={isDragDisabled}
                         key={item.id}
-                        index={index}
                         actionIcon={iconMemo}
                         {...item}
+                        index={index}
                         interactionType={interactionType}
                         itemSize={itemSize}
                         onItemAction={onItemAction}


### PR DESCRIPTION
Хочется стилизовать контейнер галереи, а пропсы не прокинуты
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-b2c@1.25.0-canary.965.45f52c0c67c1d2f110a60f3bfa16339b7b7dc0bb.0
  npm install @sberdevices/showcase@0.80.0-canary.965.45f52c0c67c1d2f110a60f3bfa16339b7b7dc0bb.0
  npm install @sberdevices/plasma-website@0.14.0-canary.965.45f52c0c67c1d2f110a60f3bfa16339b7b7dc0bb.0
  # or 
  yarn add @sberdevices/plasma-b2c@1.25.0-canary.965.45f52c0c67c1d2f110a60f3bfa16339b7b7dc0bb.0
  yarn add @sberdevices/showcase@0.80.0-canary.965.45f52c0c67c1d2f110a60f3bfa16339b7b7dc0bb.0
  yarn add @sberdevices/plasma-website@0.14.0-canary.965.45f52c0c67c1d2f110a60f3bfa16339b7b7dc0bb.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
