### PR TITLE
fix(plasma-temple): Fix time chop in VideoPlayer

### DIFF
--- a/packages/plasma-temple/src/components/MediaPlayer/MediaPlayerTimeline.tsx
+++ b/packages/plasma-temple/src/components/MediaPlayer/MediaPlayerTimeline.tsx
@@ -68,14 +68,16 @@ export const MediaPlayerTimeline = <T extends PlayerType>({
     className,
     playerRef,
     onTimeUpdate,
-    currentTime = 0,
+    currentTime,
     duration = 0,
     showTick = true,
 }: MediaPlayerTimelineProps<T>): React.ReactElement => {
     const [mediaData, setMediaData] = React.useState({
         duration,
-        currentTime,
+        currentTime: 0,
     });
+    const currentTimeValue = currentTime ?? mediaData.currentTime;
+    const durationValue = duration || mediaData.duration;
 
     const updateTime = React.useCallback(() => {
         if (!playerRef.current) {
@@ -83,15 +85,16 @@ export const MediaPlayerTimeline = <T extends PlayerType>({
         }
 
         const node = playerRef.current;
+        const currentTimeSafe = currentTime ?? 0;
 
-        onTimeUpdate?.(node.currentTime + currentTime);
+        onTimeUpdate?.(node.currentTime + currentTimeSafe);
         setMediaData((prevData) => ({
             ...prevData,
-            currentTime: node.currentTime + currentTime,
+            currentTime: node.currentTime + currentTimeSafe,
         }));
     }, [onTimeUpdate, playerRef, currentTime]);
 
-    const timelinePosition = (mediaData.currentTime / mediaData.duration) * 100;
+    const timelinePosition = (currentTimeValue / durationValue) * 100;
 
     React.useLayoutEffect(() => {
         if (!playerRef.current) {
@@ -103,7 +106,7 @@ export const MediaPlayerTimeline = <T extends PlayerType>({
         node.addEventListener(
             'canplaythrough',
             () => {
-                if (duration === 0 && currentTime === 0) {
+                if (duration === 0 && !currentTime) {
                     setMediaData({
                         duration: node.duration,
                         currentTime: node.currentTime,
@@ -122,7 +125,7 @@ export const MediaPlayerTimeline = <T extends PlayerType>({
     }, [playerRef.current, updateTime, currentTime, duration]);
 
     React.useEffect(() => {
-        if (duration !== mediaData.duration) {
+        if (duration && duration !== mediaData.duration) {
             setMediaData({
                 ...mediaData,
                 duration,
@@ -132,12 +135,12 @@ export const MediaPlayerTimeline = <T extends PlayerType>({
 
     return (
         <StyledWrapper className={className}>
-            <StyledTime>{formatTime(mediaData.currentTime)}</StyledTime>
+            <StyledTime>{formatTime(currentTimeValue)}</StyledTime>
             <StyledTimeLine>
                 <StyledProgress style={{ width: `${timelinePosition}%` }} />
                 {showTick && <StyledTimelineTick style={{ left: `${timelinePosition}%` }} />}
             </StyledTimeLine>
-            <StyledTime>{formatTime(mediaData.duration)}</StyledTime>
+            <StyledTime>{formatTime(durationValue)}</StyledTime>
         </StyledWrapper>
     );
 };

--- a/packages/plasma-temple/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/packages/plasma-temple/src/components/VideoPlayer/VideoPlayer.tsx
@@ -104,7 +104,7 @@ export const VideoPlayer = React.memo(
         customControls: CustomControlsComponent,
         visibleControlList,
         children,
-        startTime,
+        startTime = 0,
         endTime,
         autoPlay,
         muted,
@@ -146,6 +146,8 @@ export const VideoPlayer = React.memo(
             }),
             [actions, goBack, goNext],
         );
+
+        const controlledTimeLineProps = startTime && endTime ? { currentTime, duration: endTime - startTime } : {};
 
         const finished = Boolean(duration) && currentTime >= duration;
         const playerState = { ...state, backDisabled, nextDisabled, finished };
@@ -189,7 +191,7 @@ export const VideoPlayer = React.memo(
                             canPlay={!loading}
                         />
                         {isControlVisible(ControlType.TIMELINE, visibleControlList) && (
-                            <MediaPlayerTimeline playerRef={playerRef} />
+                            <MediaPlayerTimeline playerRef={playerRef} {...controlledTimeLineProps} />
                         )}
                     </StyledControlsWrapper>
                 </StyledOverlay>


### PR DESCRIPTION
Исправил обработку значений startTime и endTime для VideoPlayer. Теперь можно передать эти значения и видео будет воспроизводиться только из заданного участка
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/demo-canvas-app@0.48.1-canary.966.23bf463d3f8961862e4c09bf460dfd29ea9cb6a4.0
  npm install @sberdevices/plasma-b2c@1.27.2-canary.966.23bf463d3f8961862e4c09bf460dfd29ea9cb6a4.0
  npm install @sberdevices/plasma-core@1.41.1-canary.966.23bf463d3f8961862e4c09bf460dfd29ea9cb6a4.0
  npm install @sberdevices/plasma-icons@1.58.1-canary.966.23bf463d3f8961862e4c09bf460dfd29ea9cb6a4.0
  npm install @sberdevices/plasma-temple@1.10.1-canary.966.23bf463d3f8961862e4c09bf460dfd29ea9cb6a4.0
  npm install @sberdevices/plasma-ui@1.71.1-canary.966.23bf463d3f8961862e4c09bf460dfd29ea9cb6a4.0
  npm install @sberdevices/plasma-web@1.65.1-canary.966.23bf463d3f8961862e4c09bf460dfd29ea9cb6a4.0
  npm install @sberdevices/plasma-sb-utils@0.40.1-canary.966.23bf463d3f8961862e4c09bf460dfd29ea9cb6a4.0
  npm install @sberdevices/showcase@0.82.2-canary.966.23bf463d3f8961862e4c09bf460dfd29ea9cb6a4.0
  npm install @sberdevices/plasma-ui-docs@0.31.1-canary.966.23bf463d3f8961862e4c09bf460dfd29ea9cb6a4.0
  npm install @sberdevices/plasma-web-docs@0.22.1-canary.966.23bf463d3f8961862e4c09bf460dfd29ea9cb6a4.0
  npm install @sberdevices/plasma-website@0.16.2-canary.966.23bf463d3f8961862e4c09bf460dfd29ea9cb6a4.0
  # or 
  yarn add @sberdevices/demo-canvas-app@0.48.1-canary.966.23bf463d3f8961862e4c09bf460dfd29ea9cb6a4.0
  yarn add @sberdevices/plasma-b2c@1.27.2-canary.966.23bf463d3f8961862e4c09bf460dfd29ea9cb6a4.0
  yarn add @sberdevices/plasma-core@1.41.1-canary.966.23bf463d3f8961862e4c09bf460dfd29ea9cb6a4.0
  yarn add @sberdevices/plasma-icons@1.58.1-canary.966.23bf463d3f8961862e4c09bf460dfd29ea9cb6a4.0
  yarn add @sberdevices/plasma-temple@1.10.1-canary.966.23bf463d3f8961862e4c09bf460dfd29ea9cb6a4.0
  yarn add @sberdevices/plasma-ui@1.71.1-canary.966.23bf463d3f8961862e4c09bf460dfd29ea9cb6a4.0
  yarn add @sberdevices/plasma-web@1.65.1-canary.966.23bf463d3f8961862e4c09bf460dfd29ea9cb6a4.0
  yarn add @sberdevices/plasma-sb-utils@0.40.1-canary.966.23bf463d3f8961862e4c09bf460dfd29ea9cb6a4.0
  yarn add @sberdevices/showcase@0.82.2-canary.966.23bf463d3f8961862e4c09bf460dfd29ea9cb6a4.0
  yarn add @sberdevices/plasma-ui-docs@0.31.1-canary.966.23bf463d3f8961862e4c09bf460dfd29ea9cb6a4.0
  yarn add @sberdevices/plasma-web-docs@0.22.1-canary.966.23bf463d3f8961862e4c09bf460dfd29ea9cb6a4.0
  yarn add @sberdevices/plasma-website@0.16.2-canary.966.23bf463d3f8961862e4c09bf460dfd29ea9cb6a4.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
