### PR TITLE
fix(palsma-b2c): preview gallery data contracts

### DIFF
--- a/packages/plasma-b2c/src/components/PreviewGallery/PreviewGallery.tsx
+++ b/packages/plasma-b2c/src/components/PreviewGallery/PreviewGallery.tsx
@@ -16,7 +16,7 @@ export interface PreviewGalleryProps {
     /**
      * Массив элементов.
      */
-    items?: Array<PreviewGalleryItemProps & SortableElementProps>;
+    items?: Array<PreviewGalleryItemProps & Omit<SortableElementProps, 'index'>>;
     /**
      * Тип взаимодействия с галереей - выбор или перетаскивание элементов.
      */

--- a/packages/plasma-b2c/src/components/PreviewGallery/PreviewGalleryItems.tsx
+++ b/packages/plasma-b2c/src/components/PreviewGallery/PreviewGalleryItems.tsx
@@ -28,7 +28,7 @@ export const StyledRoot = styled.div<{ isGrabbing: boolean; maxHeight?: number }
 `;
 
 export interface PreviewGalleryListItemsProps {
-    items?: Array<PreviewGalleryItemProps & SortableElementProps>;
+    items?: Array<PreviewGalleryItemProps & Omit<SortableElementProps, 'index'>>;
     /**
      * Перетаскивается ли элемент.
      */


### PR DESCRIPTION
Фикс контракта галереи, убрал из пропсов индекс тк он проставляется автоматом
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-b2c@1.27.1-canary.967.1f2c6b20806e6ace8a3ec00fbd7d7ce24b262aef.0
  npm install @sberdevices/showcase@0.82.1-canary.967.1f2c6b20806e6ace8a3ec00fbd7d7ce24b262aef.0
  npm install @sberdevices/plasma-website@0.16.1-canary.967.1f2c6b20806e6ace8a3ec00fbd7d7ce24b262aef.0
  # or 
  yarn add @sberdevices/plasma-b2c@1.27.1-canary.967.1f2c6b20806e6ace8a3ec00fbd7d7ce24b262aef.0
  yarn add @sberdevices/showcase@0.82.1-canary.967.1f2c6b20806e6ace8a3ec00fbd7d7ce24b262aef.0
  yarn add @sberdevices/plasma-website@0.16.1-canary.967.1f2c6b20806e6ace8a3ec00fbd7d7ce24b262aef.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
