### PR TITLE
fix(plasma-temple): Always show player controls on key press

### DIFF
--- a/packages/plasma-temple/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/packages/plasma-temple/src/components/VideoPlayer/VideoPlayer.tsx
@@ -125,7 +125,7 @@ export const VideoPlayer = React.memo(
 
         const isControlsHidden = controlsHidden && !alwaysShowControls;
 
-        const onKewDown = React.useCallback(() => !isControlsHidden && startTimer(), [isControlsHidden, startTimer]);
+        const onKewDown = React.useCallback(() => startTimer(), [startTimer]);
         useMediaPlayerKeyboard(playback, isControlsHidden, onKewDown);
 
         React.useEffect(() => {


### PR DESCRIPTION
Теперь контролы у плеера появляются при нажатии клавиш. Исправление проблемы с тем, что нельзя вызвать контролы нажатием кнопок на пульте.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-temple@1.14.1-canary.989.6c47e3c40672600af02987037c40102b20e687c5.0
  # or 
  yarn add @sberdevices/plasma-temple@1.14.1-canary.989.6c47e3c40672600af02987037c40102b20e687c5.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
