### PR TITLE
fix(plasma-temple): Fix async Layout render

### DIFF
--- a/packages/plasma-temple/src/components/Page/Page.tsx
+++ b/packages/plasma-temple/src/components/Page/Page.tsx
@@ -114,8 +114,8 @@ export const Page: PageFunctionComponent = ({
     );
 
     return (
-        <React.Suspense fallback={fallbackComponent}>
-            <Layout ignoreInsets={ignoreInsets}>
+        <Layout ignoreInsets={ignoreInsets}>
+            <React.Suspense fallback={fallbackComponent}>
                 <Component
                     name={name}
                     params={window.history.state}
@@ -131,8 +131,8 @@ export const Page: PageFunctionComponent = ({
                     fallbackComponent={fallbackComponent}
                     header={header ?? appHeader}
                 />
-            </Layout>
-        </React.Suspense>
+            </React.Suspense>
+        </Layout>
     );
 };
 


### PR DESCRIPTION
Исправление проблемы с вычислением ширины контейнера при асинхронной загрузке страницы (lazy import) 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-temple@1.15.1-canary.995.ebd4cd4c2ca4b0506ed4abbb1fe12a156c7806c4.0
  # or 
  yarn add @sberdevices/plasma-temple@1.15.1-canary.995.ebd4cd4c2ca4b0506ed4abbb1fe12a156c7806c4.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
