### PR TITLE
feat(plasma-temple): Ability to hide player controls

### DIFF
--- a/packages/plasma-temple/src/components/MediaPlayer/MediaPlayerControls.tsx
+++ b/packages/plasma-temple/src/components/MediaPlayer/MediaPlayerControls.tsx
@@ -40,57 +40,62 @@ const TimeTravelButton = ({ forward, ...restProps }: MediaPlayerButtonProps & { 
     );
 };
 
-export const MediaPlayerControls: React.FC<MediaPlayerControlsProps> = ({
-    playback,
-    goBack,
-    goNext,
-    jumpTo,
-    paused,
-    finished,
-    canPlay,
-    backDisabled,
-    nextDisabled,
-    visibleControlList,
-    className,
-}) => {
-    const IconPlayComponent = finished ? IconRepeat : IconPlay;
+export const MediaPlayerControls = React.forwardRef<HTMLDivElement, MediaPlayerControlsProps>(
+    (
+        {
+            playback,
+            goBack,
+            goNext,
+            jumpTo,
+            paused,
+            finished,
+            canPlay,
+            backDisabled,
+            nextDisabled,
+            visibleControlList,
+            className,
+        },
+        ref,
+    ) => {
+        const IconPlayComponent = finished ? IconRepeat : IconPlay;
 
-    const mountRef = React.useRef<HTMLButtonElement>(null);
-    useFocusOnMount(mountRef, { delay: 150, prevent: !canPlay, callOnce: true });
+        const mountRef = React.useRef<HTMLButtonElement>(null);
+        useFocusOnMount(mountRef, { delay: 150, prevent: !canPlay, callOnce: true });
 
-    return (
-        <StyledWrapper className={className}>
-            <MediaPlayerButton
-                disabled={backDisabled}
-                onClick={goBack}
-                visible={isControlVisible(ControlType.BACK, visibleControlList)}
-            >
-                <IconPrevious size="xs" />
-            </MediaPlayerButton>
-            <TimeTravelButton
-                onClick={() => jumpTo(-1)}
-                visible={isControlVisible(ControlType.JUMP_BACK, visibleControlList)}
-            />
-            <MediaPlayerButton
-                onClick={playback}
-                visible={isControlVisible(ControlType.PLAYBACK, visibleControlList)}
-                disabled={!canPlay}
-                ref={mountRef}
-            >
-                {paused ? <IconPlayComponent size="xs" /> : <IconPause size="xs" />}
-            </MediaPlayerButton>
-            <TimeTravelButton
-                onClick={() => jumpTo(1)}
-                visible={isControlVisible(ControlType.JUMP_FORWARD, visibleControlList)}
-                forward
-            />
-            <MediaPlayerButton
-                disabled={nextDisabled}
-                onClick={goNext}
-                visible={isControlVisible(ControlType.NEXT, visibleControlList)}
-            >
-                <IconNext size="xs" />
-            </MediaPlayerButton>
-        </StyledWrapper>
-    );
-};
+        return (
+            <StyledWrapper className={className} ref={ref}>
+                <MediaPlayerButton
+                    disabled={backDisabled}
+                    onClick={goBack}
+                    visible={isControlVisible(ControlType.BACK, visibleControlList)}
+                >
+                    <IconPrevious size="xs" />
+                </MediaPlayerButton>
+                <TimeTravelButton
+                    onClick={() => jumpTo(-1)}
+                    visible={isControlVisible(ControlType.JUMP_BACK, visibleControlList)}
+                />
+                <MediaPlayerButton
+                    onClick={playback}
+                    visible={isControlVisible(ControlType.PLAYBACK, visibleControlList)}
+                    disabled={!canPlay}
+                    ref={mountRef}
+                >
+                    {paused ? <IconPlayComponent size="xs" /> : <IconPause size="xs" />}
+                </MediaPlayerButton>
+                <TimeTravelButton
+                    onClick={() => jumpTo(1)}
+                    visible={isControlVisible(ControlType.JUMP_FORWARD, visibleControlList)}
+                    forward
+                />
+                <MediaPlayerButton
+                    disabled={nextDisabled}
+                    onClick={goNext}
+                    visible={isControlVisible(ControlType.NEXT, visibleControlList)}
+                >
+                    <IconNext size="xs" />
+                </MediaPlayerButton>
+            </StyledWrapper>
+        );
+    },
+);

--- a/packages/plasma-temple/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/packages/plasma-temple/src/components/VideoPlayer/VideoPlayer.tsx
@@ -19,6 +19,7 @@ export interface VideoPlayerProps extends React.VideoHTMLAttributes<HTMLVideoEle
     backDisabled?: boolean;
     nextDisabled?: boolean;
     alwaysShowControls?: boolean;
+    controlsHidden?: boolean;
     visibleControlList?: ControlType[];
     startTime?: number;
     endTime?: number;
@@ -101,6 +102,7 @@ export const VideoPlayer = React.memo(
         backDisabled,
         nextDisabled,
         alwaysShowControls,
+        controlsHidden: forceControlsHidden,
         customControls: CustomControlsComponent,
         visibleControlList,
         children,
@@ -123,7 +125,7 @@ export const VideoPlayer = React.memo(
 
         const { stopped: controlsHidden, startTimer, stopTimer } = useTimer(CONTROLS_HIDE_TIMEOUT);
 
-        const isControlsHidden = controlsHidden && !alwaysShowControls;
+        const isControlsHidden = forceControlsHidden || (controlsHidden && !alwaysShowControls);
 
         const onKewDown = React.useCallback(() => startTimer(), [startTimer]);
         useMediaPlayerKeyboard(playback, isControlsHidden, onKewDown);

--- a/packages/plasma-temple/src/pages/VideoPage/VideoPage.tsx
+++ b/packages/plasma-temple/src/pages/VideoPage/VideoPage.tsx
@@ -9,7 +9,7 @@ import { AnyObject } from '../../types';
 import { VideoPageState } from './types';
 
 interface VideoPageProps<T extends AnyObject = AnyObject>
-    extends Pick<VideoPlayerProps, 'autoPlay' | 'alwaysShowControls' | 'visibleControlList'> {
+    extends Pick<VideoPlayerProps, 'autoPlay' | 'alwaysShowControls' | 'visibleControlList' | 'controlsHidden'> {
     state: VideoPageState<T>;
     customControls?: React.ComponentType<CustomMediaPlayerControlsProps<HTMLVideoElement>>;
     children?: (props: CustomMediaPlayerControlsProps<HTMLVideoElement>) => React.ReactElement;
@@ -30,6 +30,7 @@ export function VideoPage<T extends AnyObject = AnyObject>({
     autoPlay,
     visibleControlList,
     alwaysShowControls,
+    controlsHidden,
     children,
     changeState,
 }: VideoPageProps<T>): React.ReactElement {
@@ -62,6 +63,7 @@ export function VideoPage<T extends AnyObject = AnyObject>({
                 autoPlay={autoPlay}
                 visibleControlList={visibleControlList}
                 alwaysShowControls={alwaysShowControls}
+                controlsHidden={controlsHidden}
                 startTime={startTime}
                 endTime={endTime}
                 goNext={onNext}


### PR DESCRIPTION
Добавил возможность скрывать контролы в `VideoPlayer`. Плюс добавил ref для `MediaPlayerControls`.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-temple@1.16.0-canary.1011.f071ff3b9fa133242bc3e14b4f976d5c84478560.0
  # or 
  yarn add @sberdevices/plasma-temple@1.16.0-canary.1011.f071ff3b9fa133242bc3e14b4f976d5c84478560.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
