### PR TITLE
fix(plasma-ui): Set `HeaderArrow` full height

### DIFF
--- a/packages/plasma-ui/src/components/Header/HeaderArrow.tsx
+++ b/packages/plasma-ui/src/components/Header/HeaderArrow.tsx
@@ -32,9 +32,10 @@ const StyledButton = styled(Button)`
         )(css`
             position: static;
             width: auto;
-            height: auto;
+            height: calc(var(--plasma-header-pt) + var(--plasma-header-height) + var(--plasma-header-pb));
             padding: 0;
             margin-right: 1rem;
+            margin-top: calc(var(--plasma-header-pt) * -1);
         `)}
 `;
 const StyledIcon = styled(IconChevronLeft)<Pick<HeaderArrowProps, 'arrow'>>`


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/demo-canvas-app@0.52.1-canary.1016.4eaa3bc9c9203f268fa09b8ede6b062621a22ded.0
  npm install @sberdevices/plasma-temple@1.17.1-canary.1016.4eaa3bc9c9203f268fa09b8ede6b062621a22ded.0
  npm install @sberdevices/plasma-ui@1.75.1-canary.1016.4eaa3bc9c9203f268fa09b8ede6b062621a22ded.0
  npm install @sberdevices/showcase@0.88.1-canary.1016.4eaa3bc9c9203f268fa09b8ede6b062621a22ded.0
  npm install @sberdevices/plasma-ui-docs@0.35.1-canary.1016.4eaa3bc9c9203f268fa09b8ede6b062621a22ded.0
  # or 
  yarn add @sberdevices/demo-canvas-app@0.52.1-canary.1016.4eaa3bc9c9203f268fa09b8ede6b062621a22ded.0
  yarn add @sberdevices/plasma-temple@1.17.1-canary.1016.4eaa3bc9c9203f268fa09b8ede6b062621a22ded.0
  yarn add @sberdevices/plasma-ui@1.75.1-canary.1016.4eaa3bc9c9203f268fa09b8ede6b062621a22ded.0
  yarn add @sberdevices/showcase@0.88.1-canary.1016.4eaa3bc9c9203f268fa09b8ede6b062621a22ded.0
  yarn add @sberdevices/plasma-ui-docs@0.35.1-canary.1016.4eaa3bc9c9203f268fa09b8ede6b062621a22ded.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
