### PR TITLE
feat(plasma-temple): Controlled video fit on video page

### DIFF
--- a/packages/plasma-temple/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/packages/plasma-temple/src/components/VideoPlayer/VideoPlayer.tsx
@@ -11,6 +11,7 @@ import { useMediaPlayerKeyboard } from '../MediaPlayer/hooks/useMediaPlayerKeybo
 import { useTimer } from '../MediaPlayer/hooks/useTimer';
 import { MediaPlayer } from '../MediaPlayer/MediaPlayer';
 import { useInsets, Insets } from '../../hooks';
+import { ObjectFit } from '../../types';
 
 export interface VideoPlayerProps extends React.VideoHTMLAttributes<HTMLVideoElement> {
     header?: React.ReactNode;
@@ -24,6 +25,7 @@ export interface VideoPlayerProps extends React.VideoHTMLAttributes<HTMLVideoEle
     startTime?: number;
     endTime?: number;
     customControls?: React.ComponentType<CustomMediaPlayerControlsProps<HTMLVideoElement>>;
+    videoFit?: ObjectFit;
     children?: (props: CustomMediaPlayerControlsProps<HTMLVideoElement>) => React.ReactElement;
     src: string;
 }
@@ -40,7 +42,7 @@ const paddingsControlsMixin = gridSizes.map((breakpoint) => {
     `);
 });
 
-const StyledContainer = styled.div`
+const StyledContainer = styled.div<{ videoFit: ObjectFit }>`
     position: relative;
     height: 100%;
     width: 100%;
@@ -48,7 +50,7 @@ const StyledContainer = styled.div`
     & > video {
         height: 100%;
         width: 100%;
-        object-fit: contain;
+        object-fit: ${({ videoFit }) => videoFit};
         background: rgba(8, 8, 8, 0.56);
     }
 `;
@@ -110,6 +112,7 @@ export const VideoPlayer = React.memo(
         endTime,
         autoPlay,
         muted,
+        videoFit = 'contain',
         ...restProps
     }: VideoPlayerProps) => {
         const insets = useInsets();
@@ -155,7 +158,7 @@ export const VideoPlayer = React.memo(
         const playerState = { ...state, backDisabled, nextDisabled, finished };
 
         return (
-            <StyledContainer onClick={startTimer}>
+            <StyledContainer onClick={startTimer} videoFit={videoFit}>
                 <MediaPlayer type="video" {...restProps} innerRef={playerRef} />
                 {loading && <StyledSpinner />}
                 <StyledOverlay transparent={isControlsHidden}>

--- a/packages/plasma-temple/src/pages/VideoPage/VideoPage.tsx
+++ b/packages/plasma-temple/src/pages/VideoPage/VideoPage.tsx
@@ -9,7 +9,10 @@ import { AnyObject } from '../../types';
 import { VideoPageState } from './types';
 
 interface VideoPageProps<T extends AnyObject = AnyObject>
-    extends Pick<VideoPlayerProps, 'autoPlay' | 'alwaysShowControls' | 'visibleControlList' | 'controlsHidden'> {
+    extends Pick<
+        VideoPlayerProps,
+        'autoPlay' | 'alwaysShowControls' | 'visibleControlList' | 'controlsHidden' | 'videoFit'
+    > {
     state: VideoPageState<T>;
     customControls?: React.ComponentType<CustomMediaPlayerControlsProps<HTMLVideoElement>>;
     children?: (props: CustomMediaPlayerControlsProps<HTMLVideoElement>) => React.ReactElement;
@@ -31,6 +34,7 @@ export function VideoPage<T extends AnyObject = AnyObject>({
     visibleControlList,
     alwaysShowControls,
     controlsHidden,
+    videoFit,
     children,
     changeState,
 }: VideoPageProps<T>): React.ReactElement {
@@ -70,6 +74,7 @@ export function VideoPage<T extends AnyObject = AnyObject>({
                 goBack={onBack}
                 nextDisabled={position === videos.length - 1}
                 customControls={customControls}
+                videoFit={videoFit}
             >
                 {children}
             </VideoPlayer>


### PR DESCRIPTION
Добавил возможность контролировать `object-fit` для элемента `video` в `VideoPage`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-temple@1.18.0-canary.1023.a05aac37ab97da30bddb63a215805dd6990919d2.0
  # or 
  yarn add @sberdevices/plasma-temple@1.18.0-canary.1023.a05aac37ab97da30bddb63a215805dd6990919d2.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
