### PR TITLE
feat(plasma-ui): Overflow `Tabs` on `x` axis

### DIFF
--- a/packages/plasma-core/src/components/Tabs/Tabs.tsx
+++ b/packages/plasma-core/src/components/Tabs/Tabs.tsx
@@ -16,45 +16,37 @@ export interface TabsProps extends AsProps, DisabledProps, React.HTMLAttributes<
     stretch?: boolean;
 }
 
-const StyledTabs = styled.div<TabsProps>`
+const StyledWrapper = styled.div<TabsProps>`
+    box-sizing: border-box;
+    overflow-x: auto;
+
+    /* stylelint-disable-next-line selector-max-empty-lines, selector-nested-pattern, selector-type-no-unknown */
+    ::-webkit-scrollbar {
+        display: none;
+    }
+
     ${applyDisabled}
 
-    position: relative;
-    display: flex;
-    align-items: center;
-    box-sizing: border-box;
-    flex-wrap: nowrap;
-    justify-content: stretch;
-
-    margin: 0;
-    padding: 0;
-    width: max-content;
-
-    list-style-type: none;
-    user-select: none;
-
-    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-
     /**
-     * Стили айтемов, зависимые от модификаторов контейнера, определяем тут.
-     */
+    * Стили айтемов, зависимые от модификаторов контейнера, определяем тут.
+    */
     ${({ stretch }) =>
         stretch &&
         css`
             width: 100%;
 
             /**
-             * Айтемы помещаются максимум по 4 штуки в контейнер,
-             * а при минимальном количестве занимают максимум половину ширины.
-             */
-            & > * {
+            * Айтемы помещаются максимум по 4 штуки в контейнер,
+            * а при минимальном количестве занимают максимум половину ширины.
+            */
+            ${StyledTabItem} {
                 min-width: 25%;
                 max-width: 50%;
                 width: 100%;
             }
         `}
 
-    & > ${StyledTabItem} {
+    ${StyledTabItem} {
         ${({ disabled }) =>
             disabled &&
             css`
@@ -62,10 +54,36 @@ const StyledTabs = styled.div<TabsProps>`
             `}
     }
 `;
+const StyledTabs = styled.div`
+    position: relative;
+    display: flex;
+    align-items: center;
+    box-sizing: border-box;
+    flex-wrap: nowrap;
+    justify-content: stretch;
+
+    min-width: 100%;
+    width: max-content;
+    height: var(--plasma-tabs-list-height);
+    margin: 0;
+    padding: 0;
+
+    background: var(--plasma-tabs-list-background);
+    border-radius: var(--plasma-tabs-list-border-radius);
+
+    list-style-type: none;
+    user-select: none;
+
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+`;
 
 /**
  * Контейнер вкладок.
  */
-export const Tabs = React.forwardRef<HTMLDivElement, TabsProps>(({ role = 'tablist', ...rest }, ref) => (
-    <StyledTabs ref={ref} role={role} {...rest} />
+export const Tabs = React.forwardRef<HTMLDivElement, TabsProps>(({ role = 'tablist', as, children, ...rest }, ref) => (
+    <StyledWrapper {...rest}>
+        <StyledTabs as={as} ref={ref} role={role}>
+            {children}
+        </StyledTabs>
+    </StyledWrapper>
 ));

--- a/packages/plasma-ui/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/plasma-ui/src/components/Tabs/Tabs.stories.tsx
@@ -103,9 +103,9 @@ Default.args = {
     stretch: true,
     pilled: false,
     scaleOnInteraction: true,
-    outlined: false,
+    outlined: true,
     disabled: false,
-    animated: true,
+    animated: false,
     enableContentLeft: true,
     text: 'Label',
 };

--- a/packages/plasma-ui/src/components/Tabs/TabsView.tsx
+++ b/packages/plasma-ui/src/components/Tabs/TabsView.tsx
@@ -22,8 +22,10 @@ const sizes = {
         --tab-item-padding-y-reduced: 0.75rem;
         --tab-item-height: 3rem;
         --tab-item-border-radius: 1rem;
-        height: 3.25rem;
-        border-radius: 1.125rem;
+        --plasma-tabs-list-height: 3.25rem;
+        --plasma-tabs-list-border-radius: 1.125rem;
+
+        height: 3.5rem;
     `,
     m: (stretch: boolean) => css`
         --tabs-shifting: -${stretch ? 0.875 : 1.375}rem;
@@ -32,8 +34,10 @@ const sizes = {
         --tab-item-padding-y-reduced: 0.5rem;
         --tab-item-height: 2.5rem;
         --tab-item-border-radius: 0.75rem;
-        height: 2.75rem;
-        border-radius: 0.875rem;
+        --plasma-tabs-list-height: 2.75rem;
+        --plasma-tabs-list-border-radius: 0.875rem;
+
+        height: 3rem;
     `,
     s: (stretch: boolean) => css`
         --tabs-shifting: -${stretch ? 0.75 : 1.125}rem;
@@ -42,8 +46,10 @@ const sizes = {
         --tab-item-padding-y-reduced: 0.375rem;
         --tab-item-height: 2.25rem;
         --tab-item-border-radius: 0.75rem;
-        height: 2.5rem;
-        border-radius: 0.875rem;
+        --plasma-tabs-list-height: 2.5rem;
+        --plasma-tabs-list-border-radius: 0.875rem;
+
+        height: 2.75rem;
     `,
 };
 
@@ -95,9 +101,10 @@ export interface TabsViewProps
  * Визуальная составляющая контейнера (списка) вкладок.
  */
 export const TabsView = styled(BaseTabs)<TabsViewProps>`
-    padding: 0.125rem 0;
+    --plasma-tabs-list-background: ${({ view = 'secondary' }) => views[view]};
 
-    background-color: ${({ view = 'secondary' }) => views[view]};
+    padding: 0.125rem;
+    margin: -0.125rem;
 
     &:focus {
         outline: 0 none;
@@ -110,7 +117,7 @@ export const TabsView = styled(BaseTabs)<TabsViewProps>`
             ${
                 stretch &&
                 css`
-                    & > * {
+                    ${StyledTabItem} {
                         min-width: calc(25% - 0.25rem);
                         max-width: calc(50% - 0.25rem);
                     }
@@ -144,7 +151,7 @@ export const TabsView = styled(BaseTabs)<TabsViewProps>`
     `}
 
     /* stylelint-disable-next-line selector-max-universal */
-    & > ${StyledTabItem} {
+    ${StyledTabItem} {
         ${applyInteraction};
 
         margin-left: 0.125rem;


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/demo-canvas-app@0.54.0-canary.1027.b831f3bdc41c920342d7fb6834e2f3c587c41a40.0
  npm install @sberdevices/plasma-b2c@1.35.0-canary.1027.b831f3bdc41c920342d7fb6834e2f3c587c41a40.0
  npm install @sberdevices/plasma-core@1.47.0-canary.1027.b831f3bdc41c920342d7fb6834e2f3c587c41a40.0
  npm install @sberdevices/plasma-icons@1.64.0-canary.1027.b831f3bdc41c920342d7fb6834e2f3c587c41a40.0
  npm install @sberdevices/plasma-temple@1.20.0-canary.1027.b831f3bdc41c920342d7fb6834e2f3c587c41a40.0
  npm install @sberdevices/plasma-ui@1.77.0-canary.1027.b831f3bdc41c920342d7fb6834e2f3c587c41a40.0
  npm install @sberdevices/plasma-web@1.71.0-canary.1027.b831f3bdc41c920342d7fb6834e2f3c587c41a40.0
  npm install @sberdevices/plasma-sb-utils@0.46.0-canary.1027.b831f3bdc41c920342d7fb6834e2f3c587c41a40.0
  npm install @sberdevices/showcase@0.90.0-canary.1027.b831f3bdc41c920342d7fb6834e2f3c587c41a40.0
  npm install @sberdevices/plasma-ui-docs@0.37.0-canary.1027.b831f3bdc41c920342d7fb6834e2f3c587c41a40.0
  npm install @sberdevices/plasma-web-docs@0.28.0-canary.1027.b831f3bdc41c920342d7fb6834e2f3c587c41a40.0
  npm install @sberdevices/plasma-website@0.25.0-canary.1027.b831f3bdc41c920342d7fb6834e2f3c587c41a40.0
  # or 
  yarn add @sberdevices/demo-canvas-app@0.54.0-canary.1027.b831f3bdc41c920342d7fb6834e2f3c587c41a40.0
  yarn add @sberdevices/plasma-b2c@1.35.0-canary.1027.b831f3bdc41c920342d7fb6834e2f3c587c41a40.0
  yarn add @sberdevices/plasma-core@1.47.0-canary.1027.b831f3bdc41c920342d7fb6834e2f3c587c41a40.0
  yarn add @sberdevices/plasma-icons@1.64.0-canary.1027.b831f3bdc41c920342d7fb6834e2f3c587c41a40.0
  yarn add @sberdevices/plasma-temple@1.20.0-canary.1027.b831f3bdc41c920342d7fb6834e2f3c587c41a40.0
  yarn add @sberdevices/plasma-ui@1.77.0-canary.1027.b831f3bdc41c920342d7fb6834e2f3c587c41a40.0
  yarn add @sberdevices/plasma-web@1.71.0-canary.1027.b831f3bdc41c920342d7fb6834e2f3c587c41a40.0
  yarn add @sberdevices/plasma-sb-utils@0.46.0-canary.1027.b831f3bdc41c920342d7fb6834e2f3c587c41a40.0
  yarn add @sberdevices/showcase@0.90.0-canary.1027.b831f3bdc41c920342d7fb6834e2f3c587c41a40.0
  yarn add @sberdevices/plasma-ui-docs@0.37.0-canary.1027.b831f3bdc41c920342d7fb6834e2f3c587c41a40.0
  yarn add @sberdevices/plasma-web-docs@0.28.0-canary.1027.b831f3bdc41c920342d7fb6834e2f3c587c41a40.0
  yarn add @sberdevices/plasma-website@0.25.0-canary.1027.b831f3bdc41c920342d7fb6834e2f3c587c41a40.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
