### PR TITLE
fix(plasma-temple): don't stop video on source change

### DIFF
--- a/packages/plasma-temple/src/components/MediaPlayer/hooks/useMediaPlayer.ts
+++ b/packages/plasma-temple/src/components/MediaPlayer/hooks/useMediaPlayer.ts
@@ -61,7 +61,11 @@ export const useMediaPlayer: UseMediaPlayer = (ref, params) => {
             },
             durationChange: () => {
                 if (ref.current && !durationParams) {
-                    const { duration } = ref.current;
+                    const { duration, paused } = ref.current;
+                    // Исправление проблемы с тем, что видео иногда не воспроизводится после смены дорожки
+                    if (autoPlay && paused) {
+                        ref.current.play();
+                    }
                     setState((prevState) =>
                         updateStateDuration(prevState, duration, startTimeAbsolute, endTimeAbsolute),
                     );


### PR DESCRIPTION
Исправление проблемы с тем, что видео иногда не воспроизводится после смены дорожки
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-temple@1.24.1-canary.1036.0388c7ccc4489ff3414b73c90fda72a234c45386.0
  # or 
  yarn add @sberdevices/plasma-temple@1.24.1-canary.1036.0388c7ccc4489ff3414b73c90fda72a234c45386.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
