### PR TITLE
fix(plasma-temple): Don't pass page name to PageMethods

### DIFF
--- a/packages/plasma-temple/src/components/Page/types.ts
+++ b/packages/plasma-temple/src/components/Page/types.ts
@@ -36,7 +36,7 @@ export type PageComponent<
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     PageParamsType extends Partial<Record<keyof PageStateType, any>> = Partial<Record<keyof PageStateType, any>>
 > = React.ComponentType<
-    PageMethods<PageStateType[Name], PageStateType, PageParamsType, Name> & {
+    PageMethods<PageStateType[Name], PageStateType, PageParamsType> & {
         name: Name;
         state: PageStateType[Name];
         params: PageParamsType[Name];


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-temple@1.19.3-canary.1040.c836fd76759391a983286bd827c209fe4d99b0f1.0
  # or 
  yarn add @sberdevices/plasma-temple@1.19.3-canary.1040.c836fd76759391a983286bd827c209fe4d99b0f1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
