### PR TITLE
fix(plasma-ui): `ActionButton`: Made `pin` not required again

### DIFF
--- a/packages/plasma-ui/src/components/Button/ActionButton.tsx
+++ b/packages/plasma-ui/src/components/Button/ActionButton.tsx
@@ -15,7 +15,7 @@ import { applyInteraction, InteractionProps } from '../../mixins';
 export type ActionButtonProps = Omit<BaseProps, 'stretch' | 'pin'> &
     Partial<ButtonSizeProps> &
     Partial<ButtonViewProps> &
-    InteractionProps & { pin: Extract<PinProps['pin'], 'square-square' | 'circle-circle'> };
+    InteractionProps & { pin?: Extract<PinProps['pin'], 'square-square' | 'circle-circle'> };
 
 const buttonSizes = {
     l: {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/demo-canvas-app@0.54.1-canary.1045.d0577854b72aa4f189200dd348a61b81b5836e36.0
  npm install @sberdevices/plasma-temple@1.22.1-canary.1045.d0577854b72aa4f189200dd348a61b81b5836e36.0
  npm install @sberdevices/plasma-ui@1.77.1-canary.1045.d0577854b72aa4f189200dd348a61b81b5836e36.0
  npm install @sberdevices/showcase@0.91.1-canary.1045.d0577854b72aa4f189200dd348a61b81b5836e36.0
  npm install @sberdevices/plasma-ui-docs@0.38.1-canary.1045.d0577854b72aa4f189200dd348a61b81b5836e36.0
  # or 
  yarn add @sberdevices/demo-canvas-app@0.54.1-canary.1045.d0577854b72aa4f189200dd348a61b81b5836e36.0
  yarn add @sberdevices/plasma-temple@1.22.1-canary.1045.d0577854b72aa4f189200dd348a61b81b5836e36.0
  yarn add @sberdevices/plasma-ui@1.77.1-canary.1045.d0577854b72aa4f189200dd348a61b81b5836e36.0
  yarn add @sberdevices/showcase@0.91.1-canary.1045.d0577854b72aa4f189200dd348a61b81b5836e36.0
  yarn add @sberdevices/plasma-ui-docs@0.38.1-canary.1045.d0577854b72aa4f189200dd348a61b81b5836e36.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
