### PR TITLE
fix(plasma-temple): Realtime update for currentTime in useMediaPlayer

### DIFF
--- a/packages/plasma-temple/src/components/MediaPlayer/hooks/useMediaPlayer.ts
+++ b/packages/plasma-temple/src/components/MediaPlayer/hooks/useMediaPlayer.ts
@@ -51,6 +51,14 @@ export const useMediaPlayer: UseMediaPlayer = (ref, params) => {
                     setState((prevState) => ({ ...prevState, loading: false }));
                 }
             },
+            timeUpdate: () => {
+                if (ref.current) {
+                    setState((prevState) => ({
+                        ...prevState,
+                        ...(ref.current && { currentTime: ref.current.currentTime }),
+                    }));
+                }
+            },
             durationChange: () => {
                 if (ref.current && !durationParams) {
                     const { duration } = ref.current;
@@ -156,7 +164,7 @@ export const useMediaPlayer: UseMediaPlayer = (ref, params) => {
         state: {
             ...state,
             get currentTime() {
-                return (ref.current?.currentTime ?? 0) - startTimeAbsolute;
+                return state.currentTime - startTimeAbsolute;
             },
         },
     };


### PR DESCRIPTION
Для `useMediaPlayer`, сделал обновление в реальном времени значения `currentTime`. Кажется, что по умолчанию мы должны отдавать правильное значение `currentTime`, а не значение, которое было на момент последнего обновления состояния. Если есть возражения, то можно сделать возможность настройки этого поведения.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-temple@1.21.1-canary.1050.07819cd8bd7278bf6f478a8c88eb1ae099ed5824.0
  # or 
  yarn add @sberdevices/plasma-temple@1.21.1-canary.1050.07819cd8bd7278bf6f478a8c88eb1ae099ed5824.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
