### PR TITLE
[plasma-*]: fix typings peer deps versions

### DIFF
--- a/packages/plasma-b2c/package.json
+++ b/packages/plasma-b2c/package.json
@@ -38,8 +38,8 @@
     },
     "peerDependencies": {
         "@sberdevices/plasma-icons": "^1.0.0",
-        "react": "^16.13.1 || ^17.0.0",
-        "react-dom": "^16.13.1 || ^17.0.0",
+        "react": ">=16.13.1",
+        "react-dom": ">=16.13.1",
         "styled-components": "^5.1.1"
     },
     "devDependencies": {
@@ -80,23 +80,7 @@
         "ts-node": "10.3.0",
         "typescript": "3.9.10"
     },
-    "keywords": [
-        "design-system",
-        "react-components",
-        "ui-kit",
-        "react"
-    ],
-    "files": [
-        "components",
-        "es",
-        "hocs",
-        "hooks",
-        "mixins",
-        "tokens",
-        "types",
-        "utils",
-        "index.d.ts",
-        "index.js"
-    ],
+    "keywords": ["design-system", "react-components", "ui-kit", "react"],
+    "files": ["components", "es", "hocs", "hooks", "mixins", "tokens", "types", "utils", "index.d.ts", "index.js"],
     "sideEffects": false
 }

--- a/packages/plasma-core/package.json
+++ b/packages/plasma-core/package.json
@@ -7,24 +7,10 @@
     "main": "index.js",
     "module": "es/index.js",
     "types": "index.d.ts",
-    "files": [
-        "components",
-        "hocs",
-        "hooks",
-        "mixins",
-        "tokens",
-        "types",
-        "utils",
-        "index.d.ts",
-        "index.js",
-        "es"
-    ],
+    "files": ["components", "hocs", "hooks", "mixins", "tokens", "types", "utils", "index.d.ts", "index.js", "es"],
     "peerDependencies": {
-        "@types/node": "^12.12.30",
-        "@types/react": "^16.9.38",
-        "@types/react-dom": "^16.9.8",
-        "react": "^16.13.1 || ^17.0.0",
-        "react-dom": "^16.13.1 || ^17.0.0",
+        "react": ">=16.13.1",
+        "react-dom": ">=16.13.1",
         "styled-components": "^5.1.1"
     },
     "devDependencies": {
@@ -66,11 +52,7 @@
         "test": "NODE_ICU_DATA=node_modules/full-icu jest",
         "test:watch": "NODE_ICU_DATA=node_modules/full-icu jest --watch"
     },
-    "contributors": [
-        "Vasiliy Loginevskiy",
-        "Виноградов Антон Александрович",
-        "Зубаиров Фаниль Асхатович"
-    ],
+    "contributors": ["Vasiliy Loginevskiy", "Виноградов Антон Александрович", "Зубаиров Фаниль Асхатович"],
     "sideEffects": false,
     "dependencies": {
         "focus-visible": "5.2.0",

--- a/packages/plasma-icons/package.json
+++ b/packages/plasma-icons/package.json
@@ -13,11 +13,8 @@
     "license": "Sber Public License at-nc-sa v.2",
     "peerDependencies": {
         "@sberdevices/plasma-core": "^1.0.0",
-        "@types/node": "^12.12.30",
-        "@types/react": "^16.9.38",
-        "@types/react-dom": "^16.9.8",
-        "react": "^16.13.1 || ^17.0.0",
-        "react-dom": "^16.13.1 || ^17.0.0",
+        "react": ">=16.13.1",
+        "react-dom": ">=16.13.1",
         "styled-components": "^5.1.1"
     },
     "devDependencies": {

--- a/packages/plasma-temple/package.json
+++ b/packages/plasma-temple/package.json
@@ -11,13 +11,10 @@
     "author": "SberDevices Frontend Team <sberdevices.frontend@gmail.com>",
     "license": "Sber Public License at-nc-sa v.2",
     "peerDependencies": {
-        "@sberdevices/assistant-client": "^4.10.0",
-        "@sberdevices/plasma-icons": "^1.8.0",
-        "@sberdevices/plasma-tokens": "^1.3.0",
-        "@sberdevices/plasma-ui": "^1.11.0",
-        "@types/node": "^12.12.30",
-        "@types/react": "^16.9.38",
-        "@types/react-dom": "^16.9.8",
+        "@sberdevices/assistant-client": "^4.0.0",
+        "@sberdevices/plasma-icons": "^1.0.0",
+        "@sberdevices/plasma-tokens": "^1.0.0",
+        "@sberdevices/plasma-ui": "^1.0.0",
         "react": "^16.13.1",
         "react-dom": "^16.13.1",
         "styled-components": "^5.1.1"
@@ -79,9 +76,7 @@
         "storybook:extract": "sb extract build-sb ./build-sb/stories.json",
         "test": "jest"
     },
-    "files": [
-        "dist"
-    ],
+    "files": ["dist"],
     "contributors": [
         "Vasiliy Loginevskiy",
         "Виноградов Антон Александрович",

--- a/packages/plasma-typo/package.json
+++ b/packages/plasma-typo/package.json
@@ -15,8 +15,8 @@
         "build:esm": "tsc -p ./tsconfig.es.json"
     },
     "peerDependencies": {
-        "react": "^16.13.1 || ^17.0.0",
-        "react-dom": "^16.13.1 || ^17.0.0",
+        "react": ">=16.13.1",
+        "react-dom": ">=16.13.1",
         "styled-components": "^5.1.1"
     },
     "devDependencies": {
@@ -33,8 +33,6 @@
     "publishConfig": {
         "access": "public"
     },
-    "files": [
-        "lib"
-    ],
+    "files": ["lib"],
     "sideEffects": false
 }

--- a/packages/plasma-ui/package.json
+++ b/packages/plasma-ui/package.json
@@ -20,11 +20,8 @@
     "peerDependencies": {
         "@sberdevices/plasma-icons": "^1.0.0",
         "@sberdevices/plasma-tokens": "^1.0.0",
-        "@types/node": "^12.12.30",
-        "@types/react": "^16.9.38",
-        "@types/react-dom": "^16.9.8",
-        "react": "^16.13.1 || ^17.0.0",
-        "react-dom": "^16.13.1 || ^17.0.0",
+        "react": ">=16.13.1",
+        "react-dom": ">=16.13.1",
         "styled-components": "^5.1.1"
     },
     "devDependencies": {
@@ -92,17 +89,7 @@
             "^styled-components": "<rootDir>/node_modules/styled-components"
         }
     },
-    "files": [
-        "components",
-        "hocs",
-        "hooks",
-        "mixins",
-        "types",
-        "utils",
-        "index.d.ts",
-        "index.js",
-        "es"
-    ],
+    "files": ["components", "hocs", "hooks", "mixins", "types", "utils", "index.d.ts", "index.js", "es"],
     "contributors": [
         "Vasiliy Loginevskiy",
         "Антонов Игорь Александрович",

--- a/packages/plasma-web/package.json
+++ b/packages/plasma-web/package.json
@@ -4,27 +4,11 @@
     "description": "SberDevices Design System / React UI kit for web applications",
     "author": "SberDevices Frontend Team <sberdevices.frontend@gmail.com>",
     "license": "Sber Public License at-nc-sa v.2",
-    "keywords": [
-        "design-system",
-        "react-components",
-        "ui-kit",
-        "react"
-    ],
+    "keywords": ["design-system", "react-components", "ui-kit", "react"],
     "main": "index.js",
     "module": "es/index.js",
     "types": "index.d.ts",
-    "files": [
-        "components",
-        "es",
-        "hocs",
-        "hooks",
-        "mixins",
-        "tokens",
-        "types",
-        "utils",
-        "index.d.ts",
-        "index.js"
-    ],
+    "files": ["components", "es", "hocs", "hooks", "mixins", "tokens", "types", "utils", "index.d.ts", "index.js"],
     "repository": {
         "type": "git",
         "url": "ssh://git@github.com:sberdevices/plasma.git",
@@ -38,8 +22,8 @@
     },
     "peerDependencies": {
         "@sberdevices/plasma-icons": "^1.0.0",
-        "react": "^16.13.1 || ^17.0.0",
-        "react-dom": "^16.13.1 || ^17.0.0",
+        "react": ">=16.13.1",
+        "react-dom": ">=16.13.1",
         "styled-components": "^5.1.1"
     },
     "devDependencies": {
@@ -88,10 +72,6 @@
         "storybook:build": "build-storybook -s .storybook/public -c .storybook -o build-sb",
         "storybook:build:docs": "DOCS=true build-storybook --quiet -s .storybook/public -c .storybook -o build-sb-docs --docs"
     },
-    "contributors": [
-        "Vasiliy Loginevskiy",
-        "Anton Vinogradov",
-        "Fanil Zubairov"
-    ],
+    "contributors": ["Vasiliy Loginevskiy", "Anton Vinogradov", "Fanil Zubairov"],
     "sideEffects": false
 }

--- a/utils/plasma-cy-utils/package.json
+++ b/utils/plasma-cy-utils/package.json
@@ -12,8 +12,8 @@
         "directory": "utils/plasma-cy-utils"
     },
     "peerDependencies": {
-        "react": "^16.13.1",
-        "react-dom": "^16.13.1",
+        "react": ">=16.13.1",
+        "react-dom": ">=16.13.1",
         "styled-components": "^5.1.1"
     },
     "devDependencies": {
@@ -35,9 +35,7 @@
     "publishConfig": {
         "access": "restricted"
     },
-    "files": [
-        "lib"
-    ],
+    "files": ["lib"],
     "dependencies": {
         "@sberdevices/plasma-tokens": "1.15.1",
         "@sberdevices/plasma-tokens-b2c": "0.8.0",

--- a/utils/plasma-sb-utils/package.json
+++ b/utils/plasma-sb-utils/package.json
@@ -17,8 +17,8 @@
     "peerDependencies": {
         "@sberdevices/plasma-colors": "0.1.2",
         "@sberdevices/plasma-core": "^1.12.1",
-        "react": "^16.13.1",
-        "react-dom": "^16.13.1",
+        "react": ">=16.13.1",
+        "react-dom": ">=16.13.1",
         "styled-components": "^5.1.1"
     },
     "devDependencies": {
@@ -42,7 +42,5 @@
     "publishConfig": {
         "access": "restricted"
     },
-    "files": [
-        "lib"
-    ]
+    "files": ["lib"]
 }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/demo-canvas-app@0.57.1-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  npm install @sberdevices/plasma-b2c@1.39.1-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  npm install @sberdevices/plasma-core@1.49.1-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  npm install @sberdevices/plasma-icons@1.67.1-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  npm install @sberdevices/plasma-temple@1.26.1-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  npm install @sberdevices/plasma-typo@0.2.2-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  npm install @sberdevices/plasma-ui@1.80.1-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  npm install @sberdevices/plasma-web@1.75.1-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  npm install @sberdevices/plasma-cy-utils@0.5.2-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  npm install @sberdevices/plasma-docs-ui@0.4.1-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  npm install @sberdevices/plasma-sb-utils@0.48.1-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  npm install @sberdevices/showcase@0.94.1-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  npm install @sberdevices/plasma-temple-docs@0.5.1-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  npm install @sberdevices/plasma-ui-docs@0.41.1-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  npm install @sberdevices/plasma-web-docs@0.32.1-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  npm install @sberdevices/plasma-website@0.29.1-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  # or 
  yarn add @sberdevices/demo-canvas-app@0.57.1-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  yarn add @sberdevices/plasma-b2c@1.39.1-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  yarn add @sberdevices/plasma-core@1.49.1-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  yarn add @sberdevices/plasma-icons@1.67.1-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  yarn add @sberdevices/plasma-temple@1.26.1-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  yarn add @sberdevices/plasma-typo@0.2.2-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  yarn add @sberdevices/plasma-ui@1.80.1-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  yarn add @sberdevices/plasma-web@1.75.1-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  yarn add @sberdevices/plasma-cy-utils@0.5.2-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  yarn add @sberdevices/plasma-docs-ui@0.4.1-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  yarn add @sberdevices/plasma-sb-utils@0.48.1-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  yarn add @sberdevices/showcase@0.94.1-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  yarn add @sberdevices/plasma-temple-docs@0.5.1-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  yarn add @sberdevices/plasma-ui-docs@0.41.1-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  yarn add @sberdevices/plasma-web-docs@0.32.1-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  yarn add @sberdevices/plasma-website@0.29.1-canary.1053.bb84e31e66c83a73ad444b32404084bcf51f87d5.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
