### PR TITLE
fix(plasma-core): Add inherit cursor in label for `BaseBox` component

### DIFF
--- a/packages/plasma-core/src/components/Basebox/Basebox.tsx
+++ b/packages/plasma-core/src/components/Basebox/Basebox.tsx
@@ -38,6 +38,7 @@ export const StyledContentWrapper = styled.label`
     align-items: flex-start;
     display: flex;
     width: 100%;
+    cursor: inherit;
 `;
 
 export const StyledInput = styled.input`


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/demo-canvas-app@0.55.1-canary.1056.77d2ec501ae5353903277ebd497c588d6d37815c.0
  npm install @sberdevices/plasma-b2c@1.37.1-canary.1056.77d2ec501ae5353903277ebd497c588d6d37815c.0
  npm install @sberdevices/plasma-core@1.48.1-canary.1056.77d2ec501ae5353903277ebd497c588d6d37815c.0
  npm install @sberdevices/plasma-icons@1.65.1-canary.1056.77d2ec501ae5353903277ebd497c588d6d37815c.0
  npm install @sberdevices/plasma-temple@1.24.3-canary.1056.77d2ec501ae5353903277ebd497c588d6d37815c.0
  npm install @sberdevices/plasma-ui@1.78.1-canary.1056.77d2ec501ae5353903277ebd497c588d6d37815c.0
  npm install @sberdevices/plasma-web@1.73.1-canary.1056.77d2ec501ae5353903277ebd497c588d6d37815c.0
  npm install @sberdevices/plasma-sb-utils@0.47.1-canary.1056.77d2ec501ae5353903277ebd497c588d6d37815c.0
  npm install @sberdevices/showcase@0.92.1-canary.1056.77d2ec501ae5353903277ebd497c588d6d37815c.0
  npm install @sberdevices/plasma-ui-docs@0.39.1-canary.1056.77d2ec501ae5353903277ebd497c588d6d37815c.0
  npm install @sberdevices/plasma-web-docs@0.30.1-canary.1056.77d2ec501ae5353903277ebd497c588d6d37815c.0
  npm install @sberdevices/plasma-website@0.27.1-canary.1056.77d2ec501ae5353903277ebd497c588d6d37815c.0
  # or 
  yarn add @sberdevices/demo-canvas-app@0.55.1-canary.1056.77d2ec501ae5353903277ebd497c588d6d37815c.0
  yarn add @sberdevices/plasma-b2c@1.37.1-canary.1056.77d2ec501ae5353903277ebd497c588d6d37815c.0
  yarn add @sberdevices/plasma-core@1.48.1-canary.1056.77d2ec501ae5353903277ebd497c588d6d37815c.0
  yarn add @sberdevices/plasma-icons@1.65.1-canary.1056.77d2ec501ae5353903277ebd497c588d6d37815c.0
  yarn add @sberdevices/plasma-temple@1.24.3-canary.1056.77d2ec501ae5353903277ebd497c588d6d37815c.0
  yarn add @sberdevices/plasma-ui@1.78.1-canary.1056.77d2ec501ae5353903277ebd497c588d6d37815c.0
  yarn add @sberdevices/plasma-web@1.73.1-canary.1056.77d2ec501ae5353903277ebd497c588d6d37815c.0
  yarn add @sberdevices/plasma-sb-utils@0.47.1-canary.1056.77d2ec501ae5353903277ebd497c588d6d37815c.0
  yarn add @sberdevices/showcase@0.92.1-canary.1056.77d2ec501ae5353903277ebd497c588d6d37815c.0
  yarn add @sberdevices/plasma-ui-docs@0.39.1-canary.1056.77d2ec501ae5353903277ebd497c588d6d37815c.0
  yarn add @sberdevices/plasma-web-docs@0.30.1-canary.1056.77d2ec501ae5353903277ebd497c588d6d37815c.0
  yarn add @sberdevices/plasma-website@0.27.1-canary.1056.77d2ec501ae5353903277ebd497c588d6d37815c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
