### PR TITLE
fix(plasma-web, plasma-ui): `Basebox`: Hide input properly; tabIndex=…

### DIFF
--- a/packages/plasma-core/src/components/Basebox/Basebox.tsx
+++ b/packages/plasma-core/src/components/Basebox/Basebox.tsx
@@ -43,10 +43,6 @@ export const StyledContentWrapper = styled.label`
 
 export const StyledInput = styled.input`
     position: absolute;
-    top: 0;
-    right: 0;
-    margin: 0;
-    opacity: 0;
 
     &:focus {
         outline: 0 none;

--- a/packages/plasma-ui/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/plasma-ui/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,14 +1,22 @@
 import React from 'react';
+import styled from 'styled-components';
 
 import { SSRProvider } from '../SSRProvider';
-import { actionWithPersistedEvent, ShowcaseComponentGrid, InSpacingDecorator } from '../../helpers';
+import { actionWithPersistedEvent, InSpacingDecorator } from '../../helpers';
 
 import { Checkbox } from '.';
 
 export default {
     title: 'Controls/Checkbox',
     component: Checkbox,
-    decorators: [InSpacingDecorator],
+    decorators: [
+        InSpacingDecorator,
+        (Story: React.FC) => (
+            <SSRProvider>
+                <Story />
+            </SSRProvider>
+        ),
+    ],
 };
 
 const onChange = actionWithPersistedEvent('onChange');
@@ -21,59 +29,50 @@ const labelWithLink = (
     </div>
 );
 
-const rows = [
-    [
-        { name: 'check', value: 1, label: 'Checkbox 1', disabled: false },
-        { name: 'check', value: 2, label: 'Checkbox 2', disabled: false },
-    ],
-    [
-        { name: 'check', value: 3, label: 'Checkbox 3', disabled: true },
-        { name: 'check', value: 4, label: 'Checkbox 4', disabled: true },
-        {
-            name: 'check',
-            value: 5,
-            label: labelWithLink,
-        },
-    ],
+const items = [
+    { id: 'check-1-1', name: 'check', value: 1, label: 'Checkbox 1', disabled: false },
+    { id: 'check-1-2', name: 'check', value: 2, label: 'Checkbox 2', disabled: false },
+    { id: 'check-1-3', name: 'check', value: 3, label: 'Checkbox 3', disabled: true },
+    { id: 'check-1-4', name: 'check', value: 4, label: 'Checkbox 4', disabled: true },
+    { id: 'check-1-5', name: 'check', value: 5, label: labelWithLink },
 ];
 
-const Showcase = ({ render, withLabels = true }) => (
-    <ShowcaseComponentGrid>
-        <SSRProvider>
-            {rows.map((items) =>
-                items.map((item, j) => render({ ...item, label: withLabels ? item.label : '' }, `item:${j}`)),
-            )}
-        </SSRProvider>
-    </ShowcaseComponentGrid>
-);
+const StyledGrid = styled.div`
+    display: inline-grid;
+    grid-template-columns: repeat(2, 50%);
+    gap: 1rem;
+    align-items: flex-start;
 
-/* eslint-disable prefer-rest-params */
-export function Default() {
+    /* stylelint-disable-next-line selector-max-universal */
+    & > * + * {
+        margin-top: 0 !important;
+    }
+`;
+
+export const Default = () => {
     const [values, setValues] = React.useState([2, 4]);
 
     return (
-        <Showcase
-            {...arguments[0]}
-            render={(props, key) => (
+        <StyledGrid>
+            {items.map((item) => (
                 <Checkbox
-                    key={key}
-                    style={{ margin: 0 }}
-                    name={props.name}
-                    value={props.value}
-                    label={props.label}
-                    disabled={props.disabled}
-                    checked={values.indexOf(props.value) !== -1}
+                    key={item.id}
+                    id={item.id}
+                    name={item.name}
+                    value={item.value}
+                    label={item.label}
+                    disabled={item.disabled}
+                    checked={values.includes(item.value)}
                     onChange={(event) => {
                         setValues(
-                            [...values, props.value].filter((val) => event.target.checked || val !== props.value),
+                            event.target.checked ? [...values, item.value] : values.filter((v) => v !== item.value),
                         );
                         onChange(event);
                     }}
                     onFocus={onFocus}
                     onBlur={onBlur}
                 />
-            )}
-        />
+            ))}
+        </StyledGrid>
     );
-}
-/* eslint-enable prefer-rest-params */
+};

--- a/packages/plasma-ui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/plasma-ui/src/components/Checkbox/Checkbox.tsx
@@ -27,6 +27,13 @@ export const StyledRoot = styled(BaseboxRoot)`
         margin-top: 1.25rem;
     }
 `;
+export const StyledInput = styled(BaseboxInput)`
+    /* SberBox не видит этот элемент, нужно спрятать от глаз,
+     * но сделать достаточно большим, чтобы сфокусироваться на нем. */
+    appearance: none;
+    width: 100%;
+    height: 100%;
+`;
 export const StyledTrigger = styled(BaseboxTrigger)<{
     $focused?: boolean;
     $scaleOnInteraction?: boolean;
@@ -136,8 +143,8 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(function Che
     const uniqDescriptionId = useUniqId();
     const checkboxId = id || uniqId;
     return (
-        <StyledRoot $disabled={disabled} style={style} className={className}>
-            <BaseboxInput
+        <StyledRoot $disabled={disabled} style={style} className={className} tabIndex={-1}>
+            <StyledInput
                 aria-labelledby={uniqLabelId}
                 aria-describedby={uniqDescriptionId}
                 id={checkboxId}

--- a/packages/plasma-ui/src/components/Radiobox/Radiobox.stories.tsx
+++ b/packages/plasma-ui/src/components/Radiobox/Radiobox.stories.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 
 import { SSRProvider } from '../SSRProvider';
-import { applySpacing } from '../../mixins';
 import { actionWithPersistedEvent, InSpacingDecorator } from '../../helpers';
 
 import { Radiobox, RadioGroup } from '.';
@@ -10,76 +9,69 @@ import { Radiobox, RadioGroup } from '.';
 export default {
     title: 'Controls/Radiobox',
     component: Radiobox,
-    decorators: [InSpacingDecorator],
+    decorators: [
+        InSpacingDecorator,
+        (Story: React.FC) => (
+            <SSRProvider>
+                <Story />
+            </SSRProvider>
+        ),
+    ],
 };
 
 const onChange = actionWithPersistedEvent('onChange');
 const onFocus = actionWithPersistedEvent('onFocus');
 const onBlur = actionWithPersistedEvent('onBlur');
 
-const rows = [
-    [
-        { name: 'radio-1', value: 1, label: 'Radiobox 1', disabled: false },
-        { name: 'radio-1', value: 2, label: 'Radiobox 2', disabled: false },
-    ],
-    [
-        { name: 'radio-2', value: 3, label: 'Radiobox 3', disabled: true },
-        { name: 'radio-2', value: 4, label: 'Radiobox 4', disabled: true, checked: true },
-    ],
+const items = [
+    {
+        id: 'radio-1-1',
+        name: 'radio-1',
+        value: 1,
+        label: 'Radiobox with a very very very very very long label',
+        disabled: false,
+    },
+    { id: 'radio-1-2', name: 'radio-1', value: 2, label: 'Radiobox 2', disabled: false },
+    { id: 'radio-2-1', name: 'radio-2', value: 3, label: 'Radiobox 3', disabled: true },
+    { id: 'radio-2-2', name: 'radio-2', value: 4, label: 'Radiobox 4', disabled: true, checked: true },
 ];
 
-const StyledRadioGroup = styled(RadioGroup)`
-    display: flex;
-    justify-content: flex-start;
-    ${applySpacing({ mb: 20 })};
+const StyledGriddyRadioGroup = styled(RadioGroup)`
+    display: inline-grid;
+    grid-template-columns: repeat(2, 50%);
+    gap: 1rem;
+    align-items: flex-start;
+
+    /* stylelint-disable-next-line selector-max-universal */
+    & > * + * {
+        margin-top: 0 !important;
+    }
 `;
 
-const Showcase = ({ render, withLabels = true }) => (
-    <div>
-        <SSRProvider>
-            {rows.map((items, i) => (
-                <StyledRadioGroup key={i}>
-                    {items.map((item, j) => render({ ...item, label: withLabels ? item.label : '' }, `item:${j}`))}
-                </StyledRadioGroup>
-            ))}
-        </SSRProvider>
-    </div>
-);
-
-/* eslint-disable prefer-rest-params */
-export function Default() {
+export const Default = () => {
     const [value, setValue] = React.useState(2);
     return (
-        <Showcase
-            {...arguments[0]}
-            render={(props, key) => (
+        <StyledGriddyRadioGroup>
+            {items.map((item) => (
                 <Radiobox
-                    key={key}
-                    style={applySpacing({ mr: 20, mb: 0, mt: 0 }) as React.CSSProperties}
-                    name={props.name}
-                    value={props.value}
-                    label={props.label}
-                    disabled={props.disabled}
-                    checked={props.checked || props.value === value}
+                    key={item.id}
+                    id={item.id}
+                    name={item.name}
+                    value={item.value}
+                    label={item.label}
+                    disabled={item.disabled}
+                    checked={item.checked || item.value === value}
                     onChange={(event) => {
-                        setValue(props.value);
+                        setValue(item.value);
                         onChange(event);
                     }}
                     onFocus={onFocus}
                     onBlur={onBlur}
                 />
-            )}
-        />
+            ))}
+        </StyledGriddyRadioGroup>
     );
-}
-/* eslint-enable prefer-rest-params */
-
-const items = [
-    { value: 1, label: 'Radiobox with a very very very very very long label' },
-    { value: 2, label: 'Radiobox 2' },
-    { value: 3, label: 'Radiobox 3', disabled: true },
-    { value: 4, label: 'Radiobox 4', disabled: true },
-];
+};
 
 export const Squeeze = () => {
     const [value, setValue] = useState(1);

--- a/packages/plasma-ui/src/components/Radiobox/Radiobox.tsx
+++ b/packages/plasma-ui/src/components/Radiobox/Radiobox.tsx
@@ -1,18 +1,13 @@
 import React, { forwardRef } from 'react';
 import styled from 'styled-components';
-import {
-    BaseboxInput,
-    BaseboxLabel,
-    BaseboxDescription,
-    BaseboxContentWrapper,
-    useUniqId,
-} from '@sberdevices/plasma-core';
+import { BaseboxLabel, BaseboxDescription, BaseboxContentWrapper, useUniqId } from '@sberdevices/plasma-core';
 import type { BaseboxProps, FocusProps, OutlinedProps } from '@sberdevices/plasma-core';
 import { white } from '@sberdevices/plasma-tokens';
 
 import { InteractionProps } from '../../mixins';
 import {
     StyledRoot as CheckboxRoot,
+    StyledInput as CheckboxInput,
     StyledTrigger as CheckboxTrigger,
     StyledContent as CheckboxContent,
 } from '../Checkbox/Checkbox';
@@ -59,8 +54,8 @@ export const Radiobox = forwardRef<HTMLInputElement, RadioboxProps>(function Rad
     const uniqDescriptionId = useUniqId();
     const radioboxId = id || uniqId;
     return (
-        <CheckboxRoot $disabled={disabled} style={style} className={className}>
-            <BaseboxInput
+        <CheckboxRoot $disabled={disabled} style={style} className={className} tabIndex={-1}>
+            <CheckboxInput
                 aria-labelledby={uniqLabelId}
                 aria-describedby={uniqDescriptionId}
                 id={radioboxId}

--- a/packages/plasma-web/src/components/Checkbox/Checkbox.tsx
+++ b/packages/plasma-web/src/components/Checkbox/Checkbox.tsx
@@ -35,6 +35,13 @@ export const StyledRoot = styled(BaseboxRoot)<{ $disabled?: boolean }>`
 
     ${({ $disabled }) => $disabled && 'cursor: not-allowed;'}
 `;
+export const StyledInput = styled(BaseboxInput)`
+    /* Спрятать от IE */
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+`;
 export const StyledTrigger = styled(BaseboxTrigger)`
     /* stylelint-disable-next-line number-max-precision */
     margin: 0.1875rem 0; /* FixMe: Выпилить, v2.0 Привести к единому стилю с UI */
@@ -135,8 +142,8 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(function Che
     const uniqDescriptionId = useUniqId();
     const checkboxId = id || uniqId;
     return (
-        <StyledRoot $disabled={disabled} style={style} className={className}>
-            <BaseboxInput
+        <StyledRoot $disabled={disabled} style={style} className={className} tabIndex={-1}>
+            <StyledInput
                 aria-labelledby={uniqLabelId}
                 aria-describedby={uniqDescriptionId}
                 id={checkboxId}

--- a/packages/plasma-web/src/components/Radiobox/Radiobox.tsx
+++ b/packages/plasma-web/src/components/Radiobox/Radiobox.tsx
@@ -1,10 +1,11 @@
 import React, { forwardRef } from 'react';
 import styled from 'styled-components';
-import { BaseboxInput, BaseboxDescription, BaseboxContentWrapper, useUniqId, white } from '@sberdevices/plasma-core';
+import { BaseboxDescription, BaseboxContentWrapper, useUniqId, white } from '@sberdevices/plasma-core';
 import type { BaseboxProps } from '@sberdevices/plasma-core';
 
 import {
     StyledRoot as CheckboxRoot,
+    StyledInput as CheckboxInput,
     StyledTrigger as CheckboxTrigger,
     StyledContent as CheckboxContent,
     StyledLabel as CheckboxLabel,
@@ -56,8 +57,8 @@ export const Radiobox = forwardRef<HTMLInputElement, RadioboxProps>(function Rad
     const uniqDescriptionId = useUniqId();
     const radioboxId = id || uniqId;
     return (
-        <CheckboxRoot $disabled={disabled} style={style} className={className}>
-            <BaseboxInput
+        <CheckboxRoot $disabled={disabled} style={style} className={className} tabIndex={-1}>
+            <CheckboxInput
                 aria-labelledby={uniqLabelId}
                 aria-describedby={uniqDescriptionId}
                 id={radioboxId}


### PR DESCRIPTION
…{-1} on root
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/demo-canvas-app@0.55.2-canary.1057.58c80cc3940acf42ceb3f3f75800445323976b61.0
  npm install @sberdevices/plasma-b2c@1.37.2-canary.1057.58c80cc3940acf42ceb3f3f75800445323976b61.0
  npm install @sberdevices/plasma-core@1.48.2-canary.1057.58c80cc3940acf42ceb3f3f75800445323976b61.0
  npm install @sberdevices/plasma-icons@1.65.2-canary.1057.58c80cc3940acf42ceb3f3f75800445323976b61.0
  npm install @sberdevices/plasma-temple@1.24.4-canary.1057.58c80cc3940acf42ceb3f3f75800445323976b61.0
  npm install @sberdevices/plasma-ui@1.78.2-canary.1057.58c80cc3940acf42ceb3f3f75800445323976b61.0
  npm install @sberdevices/plasma-web@1.73.2-canary.1057.58c80cc3940acf42ceb3f3f75800445323976b61.0
  npm install @sberdevices/plasma-sb-utils@0.47.2-canary.1057.58c80cc3940acf42ceb3f3f75800445323976b61.0
  npm install @sberdevices/showcase@0.92.2-canary.1057.58c80cc3940acf42ceb3f3f75800445323976b61.0
  npm install @sberdevices/plasma-ui-docs@0.39.2-canary.1057.58c80cc3940acf42ceb3f3f75800445323976b61.0
  npm install @sberdevices/plasma-web-docs@0.30.2-canary.1057.58c80cc3940acf42ceb3f3f75800445323976b61.0
  npm install @sberdevices/plasma-website@0.27.2-canary.1057.58c80cc3940acf42ceb3f3f75800445323976b61.0
  # or 
  yarn add @sberdevices/demo-canvas-app@0.55.2-canary.1057.58c80cc3940acf42ceb3f3f75800445323976b61.0
  yarn add @sberdevices/plasma-b2c@1.37.2-canary.1057.58c80cc3940acf42ceb3f3f75800445323976b61.0
  yarn add @sberdevices/plasma-core@1.48.2-canary.1057.58c80cc3940acf42ceb3f3f75800445323976b61.0
  yarn add @sberdevices/plasma-icons@1.65.2-canary.1057.58c80cc3940acf42ceb3f3f75800445323976b61.0
  yarn add @sberdevices/plasma-temple@1.24.4-canary.1057.58c80cc3940acf42ceb3f3f75800445323976b61.0
  yarn add @sberdevices/plasma-ui@1.78.2-canary.1057.58c80cc3940acf42ceb3f3f75800445323976b61.0
  yarn add @sberdevices/plasma-web@1.73.2-canary.1057.58c80cc3940acf42ceb3f3f75800445323976b61.0
  yarn add @sberdevices/plasma-sb-utils@0.47.2-canary.1057.58c80cc3940acf42ceb3f3f75800445323976b61.0
  yarn add @sberdevices/showcase@0.92.2-canary.1057.58c80cc3940acf42ceb3f3f75800445323976b61.0
  yarn add @sberdevices/plasma-ui-docs@0.39.2-canary.1057.58c80cc3940acf42ceb3f3f75800445323976b61.0
  yarn add @sberdevices/plasma-web-docs@0.30.2-canary.1057.58c80cc3940acf42ceb3f3f75800445323976b61.0
  yarn add @sberdevices/plasma-website@0.27.2-canary.1057.58c80cc3940acf42ceb3f3f75800445323976b61.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
