### PR TITLE
fix: Docs base url via env VERSION_NAME

### DIFF
--- a/actions/versionate-docs/src/main.ts
+++ b/actions/versionate-docs/src/main.ts
@@ -16,7 +16,7 @@ const createBuildFolder = async () => {
 const buildDocumentation = async (docpckgName: string, prefix: string, version: string) => {
     console.log(`> Building apllication for "${docpckgName}".`);
 
-    const build = await exec(`npm run build --prefix="./website/${docpckgName}"`);
+    const build = await exec(`VERSION_NAME=${prefix}-${version} npm run build --prefix="./website/${docpckgName}"`);
 
     console.log(build.stdout, build.stderr);
 

--- a/website/plasma-temple-docs/docusaurus.config.js
+++ b/website/plasma-temple-docs/docusaurus.config.js
@@ -5,10 +5,9 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const path = require('path');
 
-const { PR_NAME } = process.env;
-const prefix = PR_NAME ? `/${PR_NAME}` : '';
-const suffix = 'temple/';
-const baseUrl = `${prefix}/${suffix}`;
+const { PR_NAME, VERSION_NAME } = process.env;
+const prefix = VERSION_NAME || !PR_NAME ? '' : `/${PR_NAME}`;
+const baseUrl = VERSION_NAME ? `/${VERSION_NAME}/` : `${prefix}/temple/`;
 
 /** @type {import('@docusaurus/types').DocusaurusConfig} */
 module.exports = {

--- a/website/plasma-ui-docs/docusaurus.config.js
+++ b/website/plasma-ui-docs/docusaurus.config.js
@@ -14,10 +14,9 @@ const pckgJson = require('./package.json');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const versionsArchived = require('./versionsArchived.json');
 
-const { PR_NAME } = process.env;
-const prefix = PR_NAME ? `/${PR_NAME}` : '';
-const suffix = 'ui/';
-const baseUrl = `${prefix}/${suffix}`;
+const { PR_NAME, VERSION_NAME } = process.env;
+const prefix = VERSION_NAME || !PR_NAME ? '' : `/${PR_NAME}`;
+const baseUrl = VERSION_NAME ? `/${VERSION_NAME}/` : `${prefix}/ui/`;
 
 /** @type {import('@docusaurus/types').DocusaurusConfig} */
 module.exports = {

--- a/website/plasma-ui-docs/versionsArchived.json
+++ b/website/plasma-ui-docs/versionsArchived.json
@@ -1,1 +1,1 @@
-{"1.78.1":"https://plasma.sberdevices.ru/ui-1.78.1/"}
+{}

--- a/website/plasma-web-docs/docusaurus.config.js
+++ b/website/plasma-web-docs/docusaurus.config.js
@@ -14,10 +14,9 @@ const pckgJson = require('./package.json');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const versionsArchived = require('./versionsArchived.json');
 
-const { PR_NAME } = process.env;
-const prefix = PR_NAME ? `/${PR_NAME}` : '';
-const suffix = 'web/';
-const baseUrl = `${prefix}/${suffix}`;
+const { PR_NAME, VERSION_NAME } = process.env;
+const prefix = VERSION_NAME || !PR_NAME ? '' : `/${PR_NAME}`;
+const baseUrl = VERSION_NAME ? `/${VERSION_NAME}/` : `${prefix}/web/`;
 
 /** @type {import('@docusaurus/types').DocusaurusConfig} */
 module.exports = {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/versionate-docs@0.1.1-canary.1062.46c2c971e915b79be6703f228e584a9f1e277ffa.0
  npm install @sberdevices/plasma-b2c@1.38.1-canary.1062.46c2c971e915b79be6703f228e584a9f1e277ffa.0
  npm install @sberdevices/plasma-temple@1.25.1-canary.1062.46c2c971e915b79be6703f228e584a9f1e277ffa.0
  npm install @sberdevices/plasma-web@1.74.1-canary.1062.46c2c971e915b79be6703f228e584a9f1e277ffa.0
  npm install @sberdevices/showcase@0.93.1-canary.1062.46c2c971e915b79be6703f228e584a9f1e277ffa.0
  npm install @sberdevices/plasma-temple-docs@0.4.2-canary.1062.46c2c971e915b79be6703f228e584a9f1e277ffa.0
  npm install @sberdevices/plasma-ui-docs@0.40.1-canary.1062.46c2c971e915b79be6703f228e584a9f1e277ffa.0
  npm install @sberdevices/plasma-web-docs@0.31.1-canary.1062.46c2c971e915b79be6703f228e584a9f1e277ffa.0
  npm install @sberdevices/plasma-website@0.28.1-canary.1062.46c2c971e915b79be6703f228e584a9f1e277ffa.0
  # or 
  yarn add @sberdevices/versionate-docs@0.1.1-canary.1062.46c2c971e915b79be6703f228e584a9f1e277ffa.0
  yarn add @sberdevices/plasma-b2c@1.38.1-canary.1062.46c2c971e915b79be6703f228e584a9f1e277ffa.0
  yarn add @sberdevices/plasma-temple@1.25.1-canary.1062.46c2c971e915b79be6703f228e584a9f1e277ffa.0
  yarn add @sberdevices/plasma-web@1.74.1-canary.1062.46c2c971e915b79be6703f228e584a9f1e277ffa.0
  yarn add @sberdevices/showcase@0.93.1-canary.1062.46c2c971e915b79be6703f228e584a9f1e277ffa.0
  yarn add @sberdevices/plasma-temple-docs@0.4.2-canary.1062.46c2c971e915b79be6703f228e584a9f1e277ffa.0
  yarn add @sberdevices/plasma-ui-docs@0.40.1-canary.1062.46c2c971e915b79be6703f228e584a9f1e277ffa.0
  yarn add @sberdevices/plasma-web-docs@0.31.1-canary.1062.46c2c971e915b79be6703f228e584a9f1e277ffa.0
  yarn add @sberdevices/plasma-website@0.28.1-canary.1062.46c2c971e915b79be6703f228e584a9f1e277ffa.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
