### PR TITLE
fix(plasma-web): `TextField`: fix `size:l` by providing $size to input

### DIFF
--- a/packages/plasma-web/src/components/TextField/TextField.tsx
+++ b/packages/plasma-web/src/components/TextField/TextField.tsx
@@ -46,7 +46,15 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(function T
             className={className}
         >
             {contentLeft && <FieldContent pos="left">{contentLeft}</FieldContent>}
-            <StyledInput ref={ref} id={id} placeholder={placeLabel} disabled={disabled} status={status} {...rest} />
+            <StyledInput
+                ref={ref}
+                id={id}
+                $size={size}
+                placeholder={placeLabel}
+                disabled={disabled}
+                status={status}
+                {...rest}
+            />
             {placeLabel && size === 'l' && <FieldPlaceholder htmlFor={id}>{placeLabel}</FieldPlaceholder>}
             {contentRight && <FieldContent pos="right">{contentRight}</FieldContent>}
             {helperText && <FieldHelper>{helperText}</FieldHelper>}


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-b2c@1.39.3-canary.1073.628a58536e7f27c3a4aae03f14e33035d42d878d.0
  npm install @sberdevices/plasma-temple@1.27.3-canary.1073.628a58536e7f27c3a4aae03f14e33035d42d878d.0
  npm install @sberdevices/plasma-web@1.75.3-canary.1073.628a58536e7f27c3a4aae03f14e33035d42d878d.0
  npm install @sberdevices/showcase@0.95.2-canary.1073.628a58536e7f27c3a4aae03f14e33035d42d878d.0
  npm install @sberdevices/plasma-ui-docs@0.42.2-canary.1073.628a58536e7f27c3a4aae03f14e33035d42d878d.0
  npm install @sberdevices/plasma-web-docs@0.32.3-canary.1073.628a58536e7f27c3a4aae03f14e33035d42d878d.0
  npm install @sberdevices/plasma-website@0.29.3-canary.1073.628a58536e7f27c3a4aae03f14e33035d42d878d.0
  # or 
  yarn add @sberdevices/plasma-b2c@1.39.3-canary.1073.628a58536e7f27c3a4aae03f14e33035d42d878d.0
  yarn add @sberdevices/plasma-temple@1.27.3-canary.1073.628a58536e7f27c3a4aae03f14e33035d42d878d.0
  yarn add @sberdevices/plasma-web@1.75.3-canary.1073.628a58536e7f27c3a4aae03f14e33035d42d878d.0
  yarn add @sberdevices/showcase@0.95.2-canary.1073.628a58536e7f27c3a4aae03f14e33035d42d878d.0
  yarn add @sberdevices/plasma-ui-docs@0.42.2-canary.1073.628a58536e7f27c3a4aae03f14e33035d42d878d.0
  yarn add @sberdevices/plasma-web-docs@0.32.3-canary.1073.628a58536e7f27c3a4aae03f14e33035d42d878d.0
  yarn add @sberdevices/plasma-website@0.29.3-canary.1073.628a58536e7f27c3a4aae03f14e33035d42d878d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
