### PR TITLE
feat(plasma-temple): Ability to disable autofocus in HeroSlider

### DIFF
--- a/packages/plasma-temple/src/components/HeroSlide/HeroSlide.tsx
+++ b/packages/plasma-temple/src/components/HeroSlide/HeroSlide.tsx
@@ -8,6 +8,7 @@ import { UnifiedComponentProps } from '../../registry/types';
 import { isSberBoxLike } from '../../utils/deviceFamily';
 
 export interface HeroSlideProps {
+    autofocus: boolean;
     src: string;
     onClick: React.MouseEventHandler<HTMLButtonElement>;
     title: string;
@@ -29,6 +30,7 @@ type PlatformComponents = {
 };
 
 export const HeroSlide: React.FC<UnifiedComponentProps<HeroSlideProps, PlatformComponents>> = ({
+    autofocus,
     title,
     buttonText,
     src,
@@ -40,7 +42,7 @@ export const HeroSlide: React.FC<UnifiedComponentProps<HeroSlideProps, PlatformC
 }) => {
     const { Title, Suggest, Button, Wrapper } = platformComponents;
     const mountRef = React.useRef<HTMLButtonElement>(null);
-    useFocusOnMount(mountRef, { delay: 100 });
+    useFocusOnMount(mountRef, { delay: 100, prevent: !autofocus });
 
     return (
         <Wrapper>

--- a/packages/plasma-temple/src/components/HeroSlider/HeroSlider@common.tsx
+++ b/packages/plasma-temple/src/components/HeroSlider/HeroSlider@common.tsx
@@ -99,6 +99,7 @@ export const HeroSlider: React.FC<UnifiedComponentProps<HeroSliderProps, Platfor
     withTimeline = true,
     initialIndex = 0,
     items,
+    disableAutofocus,
     onItemClick,
     onActiveItemChange,
     buttonText,
@@ -164,7 +165,14 @@ export const HeroSlider: React.FC<UnifiedComponentProps<HeroSliderProps, Platfor
 
     return (
         <Wrapper ref={containerRef}>
-            <Slide {...item} onClick={handleClick} buttonText={buttonText} onFocus={handleFocus} onBlur={handleBlur}>
+            <Slide
+                {...item}
+                autofocus={!disableAutofocus}
+                onClick={handleClick}
+                buttonText={buttonText}
+                onFocus={handleFocus}
+                onBlur={handleBlur}
+            >
                 {withTimeline && <HeroDots count={childLen.current} current={activeIndex} time={time} />}
             </Slide>
         </Wrapper>

--- a/packages/plasma-temple/src/components/HeroSlider/types.ts
+++ b/packages/plasma-temple/src/components/HeroSlider/types.ts
@@ -8,6 +8,7 @@ export interface HeroSliderProps {
     time?: number;
     withTimeline?: boolean;
     initialIndex?: number;
+    disableAutofocus?: boolean;
     items: HeroItemSliderProps[];
     onItemClick?: (item: HeroItemSliderProps, index: number) => void;
     onActiveItemChange?: (item: HeroItemSliderProps, index: number) => void;


### PR DESCRIPTION
Возможность отключить автофокус в `HeroSlider`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-temple@1.29.0-canary.1077.3ab858da764e1ebee82d28be545a6d46944c55f6.0
  # or 
  yarn add @sberdevices/plasma-temple@1.29.0-canary.1077.3ab858da764e1ebee82d28be545a6d46944c55f6.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
