### PR TITLE
feat(plasma-temple): Config initial index in HeroSlider

### DIFF
--- a/packages/plasma-temple/src/components/HeroSlider/HeroSlider@common.tsx
+++ b/packages/plasma-temple/src/components/HeroSlider/HeroSlider@common.tsx
@@ -97,6 +97,7 @@ type PlatformComponents = {
 export const HeroSlider: React.FC<UnifiedComponentProps<HeroSliderProps, PlatformComponents>> = ({
     time = 10000,
     withTimeline = true,
+    initialIndex = 0,
     items,
     onItemClick,
     onActiveItemChange,
@@ -110,7 +111,7 @@ export const HeroSlider: React.FC<UnifiedComponentProps<HeroSliderProps, Platfor
 
     const [activeIndex, setActiveIndex] = useRemoteHandlers({
         axis: 'x',
-        initialIndex: 0,
+        initialIndex,
         min: 0,
         max: childLen.current - 1,
         longCount: 1,
@@ -150,7 +151,7 @@ export const HeroSlider: React.FC<UnifiedComponentProps<HeroSliderProps, Platfor
     }, [item, activeIndex, onActiveItemChange]);
 
     const handleClick = React.useCallback(() => {
-        onItemClick?.(item);
+        onItemClick?.(item, activeIndex);
     }, [item, onItemClick]);
 
     const handleFocus = React.useCallback(() => {

--- a/packages/plasma-temple/src/components/HeroSlider/types.ts
+++ b/packages/plasma-temple/src/components/HeroSlider/types.ts
@@ -7,8 +7,9 @@ export interface HeroItemSliderProps extends Pick<HeroSlideProps, 'title' | 'src
 export interface HeroSliderProps {
     time?: number;
     withTimeline?: boolean;
+    initialIndex?: number;
     items: HeroItemSliderProps[];
-    onItemClick?: (item: HeroItemSliderProps) => void;
+    onItemClick?: (item: HeroItemSliderProps, index: number) => void;
     onActiveItemChange?: (item: HeroItemSliderProps, index: number) => void;
     buttonText: string;
 }


### PR DESCRIPTION
Возможность передавать `initialIndex` в `HeroSlider`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-temple@1.28.0-canary.1078.d371710cf1a2758754c0c5e8eaf8be63504c556d.0
  # or 
  yarn add @sberdevices/plasma-temple@1.28.0-canary.1078.d371710cf1a2758754c0c5e8eaf8be63504c556d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
