### PR TITLE
fix(plasma-web): `Carousel`: moved style resets to core

### DIFF
--- a/packages/plasma-core/src/components/Carousel/Carousel.tsx
+++ b/packages/plasma-core/src/components/Carousel/Carousel.tsx
@@ -18,6 +18,9 @@ export const CarouselGridWrapper = styled.div`
  */
 export const Carousel = styled.div<Pick<CarouselProps, 'axis' | 'scrollSnapType'>>`
     position: relative;
+    margin: 0;
+    padding: 0;
+    list-style: none;
 
     /* stylelint-disable-next-line selector-max-empty-lines, selector-nested-pattern, selector-type-no-unknown */
     ::-webkit-scrollbar {

--- a/packages/plasma-web/src/components/Carousel/Carousel.tsx
+++ b/packages/plasma-web/src/components/Carousel/Carousel.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
-import styled from 'styled-components';
 import {
     useCarousel,
     CarouselContext,
-    CarouselGridWrapper as BaseWrapper,
-    Carousel as BaseCarousel,
-    CarouselTrack as BaseTrack,
+    Carousel as StyledCarousel,
+    CarouselTrack as StyledCarouselTrack,
 } from '@sberdevices/plasma-core';
 import type { CarouselProps as BaseProps } from '@sberdevices/plasma-core';
 
@@ -15,15 +13,6 @@ export type CarouselProps = Omit<BaseProps, 'axis' | 'animatedScrollByIndex' | '
      */
     ariaLive?: 'off' | 'polite';
 };
-
-export const CarouselGridWrapper = styled(BaseWrapper)``;
-const StyledCarousel = styled(BaseCarousel)``;
-const StyledCarouselTrack = styled(BaseTrack)`
-    margin: 0;
-    padding: 0;
-
-    list-style: none;
-`;
 
 /**
  * Компонент для создания списков с прокруткой.

--- a/packages/plasma-web/src/components/Carousel/index.ts
+++ b/packages/plasma-web/src/components/Carousel/index.ts
@@ -1,5 +1,5 @@
-export { CarouselItem } from '@sberdevices/plasma-core';
+export { CarouselGridWrapper, CarouselItem } from '@sberdevices/plasma-core';
 export type { CarouselItemProps } from '@sberdevices/plasma-core';
 
-export { Carousel, CarouselGridWrapper } from './Carousel';
+export { Carousel } from './Carousel';
 export type { CarouselProps } from './Carousel';


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/demo-canvas-app@0.59.2-canary.1104.7afcb82860cc1a4d585a889146622c9d4920684c.0
  npm install @sberdevices/plasma-b2c@1.41.1-canary.1104.7afcb82860cc1a4d585a889146622c9d4920684c.0
  npm install @sberdevices/plasma-core@1.49.6-canary.1104.7afcb82860cc1a4d585a889146622c9d4920684c.0
  npm install @sberdevices/plasma-icons@1.67.7-canary.1104.7afcb82860cc1a4d585a889146622c9d4920684c.0
  npm install @sberdevices/plasma-temple@1.31.1-canary.1104.7afcb82860cc1a4d585a889146622c9d4920684c.0
  npm install @sberdevices/plasma-ui@1.82.2-canary.1104.7afcb82860cc1a4d585a889146622c9d4920684c.0
  npm install @sberdevices/plasma-web@1.76.2-canary.1104.7afcb82860cc1a4d585a889146622c9d4920684c.0
  npm install @sberdevices/plasma-sb-utils@0.48.6-canary.1104.7afcb82860cc1a4d585a889146622c9d4920684c.0
  npm install @sberdevices/showcase@0.97.1-canary.1104.7afcb82860cc1a4d585a889146622c9d4920684c.0
  npm install @sberdevices/plasma-ui-docs@0.43.2-canary.1104.7afcb82860cc1a4d585a889146622c9d4920684c.0
  npm install @sberdevices/plasma-web-docs@0.33.2-canary.1104.7afcb82860cc1a4d585a889146622c9d4920684c.0
  npm install @sberdevices/plasma-website@0.31.1-canary.1104.7afcb82860cc1a4d585a889146622c9d4920684c.0
  # or 
  yarn add @sberdevices/demo-canvas-app@0.59.2-canary.1104.7afcb82860cc1a4d585a889146622c9d4920684c.0
  yarn add @sberdevices/plasma-b2c@1.41.1-canary.1104.7afcb82860cc1a4d585a889146622c9d4920684c.0
  yarn add @sberdevices/plasma-core@1.49.6-canary.1104.7afcb82860cc1a4d585a889146622c9d4920684c.0
  yarn add @sberdevices/plasma-icons@1.67.7-canary.1104.7afcb82860cc1a4d585a889146622c9d4920684c.0
  yarn add @sberdevices/plasma-temple@1.31.1-canary.1104.7afcb82860cc1a4d585a889146622c9d4920684c.0
  yarn add @sberdevices/plasma-ui@1.82.2-canary.1104.7afcb82860cc1a4d585a889146622c9d4920684c.0
  yarn add @sberdevices/plasma-web@1.76.2-canary.1104.7afcb82860cc1a4d585a889146622c9d4920684c.0
  yarn add @sberdevices/plasma-sb-utils@0.48.6-canary.1104.7afcb82860cc1a4d585a889146622c9d4920684c.0
  yarn add @sberdevices/showcase@0.97.1-canary.1104.7afcb82860cc1a4d585a889146622c9d4920684c.0
  yarn add @sberdevices/plasma-ui-docs@0.43.2-canary.1104.7afcb82860cc1a4d585a889146622c9d4920684c.0
  yarn add @sberdevices/plasma-web-docs@0.33.2-canary.1104.7afcb82860cc1a4d585a889146622c9d4920684c.0
  yarn add @sberdevices/plasma-website@0.31.1-canary.1104.7afcb82860cc1a4d585a889146622c9d4920684c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
