### PR TITLE
fix(plasma-temple): Poster classname on video change

### DIFF
--- a/packages/plasma-temple/src/components/MediaPlayer/hooks/useMediaPlayer.ts
+++ b/packages/plasma-temple/src/components/MediaPlayer/hooks/useMediaPlayer.ts
@@ -76,6 +76,11 @@ export const useMediaPlayer: UseMediaPlayer = (ref, params) => {
                     setState((prevState) => ({ ...prevState, loading: true }));
                 }
             },
+            loadstart: () => {
+                if (ref.current) {
+                    setState((prevState) => ({ ...prevState, loading: true }));
+                }
+            },
         }),
         [end, ref, start],
     );

--- a/packages/plasma-temple/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/packages/plasma-temple/src/components/VideoPlayer/VideoPlayer.tsx
@@ -131,11 +131,15 @@ export const VideoPlayer = React.memo(
         const { currentTime, duration, loading, paused } = state;
         const [isPosterShowing, setIsPosterShowing] = React.useState(true);
 
-        React.useEffect(() => {
-            if (isPosterShowing && !loading && !paused) {
+        React.useLayoutEffect(() => {
+            const isOnStart = currentTime === 0;
+            if (isPosterShowing && !loading && !isOnStart) {
                 setIsPosterShowing(false);
             }
-        }, [isPosterShowing, loading, paused]);
+            if (!isPosterShowing && loading && isOnStart) {
+                setIsPosterShowing(true);
+            }
+        }, [isPosterShowing, loading, currentTime]);
 
         const { stopped: controlsHidden, startTimer, stopTimer } = useTimer(CONTROLS_HIDE_TIMEOUT);
 


### PR DESCRIPTION
Исправление проставления classname для постера при переключении видео

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-temple@1.35.1-canary.1132.b268fd8a0a2739c0b915169676744434cf237f1f.0
  npm install @sberdevices/plasma-temple-docs@0.7.1-canary.1132.b268fd8a0a2739c0b915169676744434cf237f1f.0
  # or 
  yarn add @sberdevices/plasma-temple@1.35.1-canary.1132.b268fd8a0a2739c0b915169676744434cf237f1f.0
  yarn add @sberdevices/plasma-temple-docs@0.7.1-canary.1132.b268fd8a0a2739c0b915169676744434cf237f1f.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
