### PR TITLE
fix(plasma-web-docs): Docusaurus docgen plugin's json fail

### DIFF
--- a/website/plasma-web-docs/docusaurus.config.js
+++ b/website/plasma-web-docs/docusaurus.config.js
@@ -182,10 +182,19 @@ module.exports = {
                                 module.displayName !== 'Default'
                             );
                         })
-                        .map((component) =>
+                        .forEach(async (component) =>
                             actions.createData(
                                 `${component.displayName}.json`,
-                                JSON.stringify({ props: component.props, description: component.description }),
+                                JSON.stringify({
+                                    props: Object.entries(component.props).reduce(
+                                        (acc, [key, { declarations, parent, ...rest }]) => ({
+                                            ...acc,
+                                            [key]: rest,
+                                        }),
+                                        {},
+                                    ),
+                                    description: component.description,
+                                }),
                             ),
                         );
                 },


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-web-docs@0.36.1-canary.1138.fa6b2a407f0f5071d6622ee76ea121527c78c520.0
  # or 
  yarn add @sberdevices/plasma-web-docs@0.36.1-canary.1138.fa6b2a407f0f5071d6622ee76ea121527c78c520.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
