### PR TITLE
feat(plasma-temple): Export for useSpatNavBetweenTargets

### DIFF
--- a/packages/plasma-temple/src/hooks/index.ts
+++ b/packages/plasma-temple/src/hooks/index.ts
@@ -12,4 +12,4 @@ export * from './useFocusOnMount';
 export * from './useForm';
 export * from './useGetMutableValue';
 export * from './useWindowInnerHeight';
-export { useSpatNav } from './useSpatNav';
+export { useSpatNav, useSpatNavBetweenTargets } from './useSpatNav';


### PR DESCRIPTION
Экспорт для `useSpatNavBetweenTargets`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-temple@1.43.0-canary.1140.5cdddf9630e499a17e740147871770cf43afcf51.0
  # or 
  yarn add @sberdevices/plasma-temple@1.43.0-canary.1140.5cdddf9630e499a17e740147871770cf43afcf51.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
