### PR TITLE
docs(plasma-web, plasma-ui): `Toast`: added `showToast` arguments des…

### DIFF
--- a/website/plasma-web-docs/docs/components/Toast.mdx
+++ b/website/plasma-web-docs/docs/components/Toast.mdx
@@ -15,7 +15,7 @@ import { PropsTable, Description, StorybookLink } from '@site/src/components';
 
 ```tsx live
 import React from 'react';
-import { Toast } from '@sberdevices/plasma-ui';
+import { Toast } from '@sberdevices/plasma-web';
 
 export function App() {
     return (

--- a/website/plasma-web-docs/src/components/Storybook.tsx
+++ b/website/plasma-web-docs/src/components/Storybook.tsx
@@ -22,6 +22,7 @@ const storyLinks = {
     Tabs: 'controls-tabs--default',
     TextArea: 'controls-textarea--default',
     TextField: 'controls-textfield--default',
+    Toast: 'controls-toast--default',
     Tooltip: 'controls-tooltip--live',
     Typography: 'content-typography--default',
 };


### PR DESCRIPTION
…cription
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @sberdevices/plasma-ui-docs@0.60.1-canary.1177.f054471988795069591e4ec0387bfb82ff62220c.0
  npm install @sberdevices/plasma-web-docs@0.47.1-canary.1177.f054471988795069591e4ec0387bfb82ff62220c.0
  # or 
  yarn add @sberdevices/plasma-ui-docs@0.60.1-canary.1177.f054471988795069591e4ec0387bfb82ff62220c.0
  yarn add @sberdevices/plasma-web-docs@0.47.1-canary.1177.f054471988795069591e4ec0387bfb82ff62220c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
